### PR TITLE
Auto-initialize memory DB, Ollama, and config during install

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -7,14 +7,7 @@ export const doctorCommand = new Command('doctor')
   .option('--fix', 'Attempt to fix issues automatically')
   .action(async (options) => {
     console.log(chalk.cyan('\n🔍 Zouroboros Health Check\n'));
-    
+
     const healthy = await runDoctor({ fix: options.fix });
-    
-    if (healthy) {
-      console.log(chalk.green('\n✅ All systems healthy\n'));
-      process.exit(0);
-    } else {
-      console.log(chalk.yellow('\n⚠️  Some issues found\n'));
-      process.exit(1);
-    }
+    process.exit(healthy ? 0 : 1);
   });

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
 import { loadConfig, saveConfig, DEFAULT_CONFIG } from 'zouroboros-core';
@@ -10,6 +11,7 @@ export const initCommand = new Command('init')
   .description('Initialize Zouroboros configuration')
   .option('-f, --force', 'Overwrite existing configuration')
   .option('--skip-doctor', 'Skip health check after initialization')
+  .option('--skip-ollama', 'Skip Ollama installation')
   .action(async (options) => {
     console.log(chalk.cyan('\n🐍⭕ Initializing Zouroboros...\n'));
 
@@ -52,11 +54,182 @@ export const initCommand = new Command('init')
     console.log(chalk.green('✅ Workspace directories created'));
     console.log(chalk.gray(`   ${configDir}/{logs,seeds,results}\n`));
 
+    // Initialize memory database
+    console.log(chalk.cyan('💾 Initializing memory database...'));
+    try {
+      const dbPath = config.memory.dbPath;
+      const dbDir = join(dbPath, '..');
+      mkdirSync(dbDir, { recursive: true });
+
+      // Use sqlite3 CLI to create the schema (avoids needing bun:sqlite at install time)
+      const schemaSql = `
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS facts (
+  id TEXT PRIMARY KEY,
+  persona TEXT,
+  entity TEXT NOT NULL,
+  key TEXT,
+  value TEXT NOT NULL,
+  text TEXT NOT NULL,
+  category TEXT DEFAULT 'fact' CHECK(category IN ('preference', 'fact', 'decision', 'convention', 'other', 'reference', 'project')),
+  decay_class TEXT DEFAULT 'medium' CHECK(decay_class IN ('permanent', 'long', 'medium', 'short')),
+  importance REAL DEFAULT 1.0,
+  source TEXT,
+  created_at INTEGER DEFAULT (strftime('%s', 'now')),
+  expires_at INTEGER,
+  last_accessed INTEGER DEFAULT (strftime('%s', 'now')),
+  confidence REAL DEFAULT 1.0,
+  metadata TEXT
+);
+
+CREATE TABLE IF NOT EXISTS fact_embeddings (
+  fact_id TEXT PRIMARY KEY REFERENCES facts(id) ON DELETE CASCADE,
+  embedding BLOB NOT NULL,
+  model TEXT DEFAULT 'nomic-embed-text',
+  created_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS episodes (
+  id TEXT PRIMARY KEY,
+  summary TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK(outcome IN ('success', 'failure', 'resolved', 'ongoing')),
+  happened_at INTEGER NOT NULL,
+  duration_ms INTEGER,
+  procedure_id TEXT,
+  metadata TEXT,
+  created_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS episode_entities (
+  episode_id TEXT NOT NULL REFERENCES episodes(id) ON DELETE CASCADE,
+  entity TEXT NOT NULL,
+  PRIMARY KEY (episode_id, entity)
+);
+
+CREATE TABLE IF NOT EXISTS procedures (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  version INTEGER DEFAULT 1,
+  steps TEXT NOT NULL,
+  success_count INTEGER DEFAULT 0,
+  failure_count INTEGER DEFAULT 0,
+  evolved_from TEXT,
+  created_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS open_loops (
+  id TEXT PRIMARY KEY,
+  summary TEXT NOT NULL,
+  entity TEXT NOT NULL,
+  status TEXT DEFAULT 'open' CHECK(status IN ('open', 'resolved')),
+  priority INTEGER DEFAULT 1,
+  created_at INTEGER DEFAULT (strftime('%s', 'now')),
+  resolved_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS continuation_context (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  last_summary TEXT NOT NULL,
+  open_loop_ids TEXT,
+  entity_stack TEXT,
+  last_agent TEXT,
+  updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS cognitive_profiles (
+  entity TEXT PRIMARY KEY,
+  traits TEXT,
+  preferences TEXT,
+  interaction_count INTEGER DEFAULT 0,
+  last_interaction INTEGER,
+  created_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE TABLE IF NOT EXISTS _migrations (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  applied_at INTEGER DEFAULT (strftime('%s', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_entity_key ON facts(entity, key);
+CREATE INDEX IF NOT EXISTS idx_facts_decay ON facts(decay_class, expires_at);
+CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_episodes_happened ON episodes(happened_at);
+CREATE INDEX IF NOT EXISTS idx_episodes_outcome ON episodes(outcome);
+CREATE INDEX IF NOT EXISTS idx_episode_entities ON episode_entities(entity);
+CREATE INDEX IF NOT EXISTS idx_open_loops_entity ON open_loops(entity, status);
+`;
+
+      execSync(`sqlite3 "${dbPath}" <<'SCHEMA'\n${schemaSql}\nSCHEMA`, {
+        shell: '/bin/bash',
+        stdio: 'pipe',
+      });
+
+      console.log(chalk.green('✅ Memory database initialized'));
+      console.log(chalk.gray(`   ${dbPath}\n`));
+    } catch (error) {
+      console.log(chalk.yellow('⚠️  Memory database initialization failed — will be created on first use'));
+      console.log(chalk.gray(`   ${error instanceof Error ? error.message : String(error)}\n`));
+    }
+
+    // Install Ollama if not present
+    if (!options.skipOllama) {
+      console.log(chalk.cyan('🦙 Checking Ollama...'));
+
+      let ollamaAvailable = false;
+      try {
+        execSync('command -v ollama', { stdio: 'pipe' });
+        ollamaAvailable = true;
+        console.log(chalk.green('✅ Ollama already installed'));
+      } catch {
+        console.log(chalk.gray('   Ollama not found — installing...'));
+        try {
+          execSync('curl -fsSL https://ollama.com/install.sh | sh', {
+            stdio: 'inherit',
+            timeout: 120000,
+          });
+          ollamaAvailable = true;
+          console.log(chalk.green('✅ Ollama installed'));
+        } catch (error) {
+          console.log(chalk.yellow('⚠️  Ollama installation failed — vector search will be limited'));
+          console.log(chalk.gray('   Install manually: https://ollama.com/download\n'));
+        }
+      }
+
+      // Pull the embedding model if Ollama is available
+      if (ollamaAvailable) {
+        console.log(chalk.gray('   Pulling embedding model (nomic-embed-text)...'));
+        try {
+          // Ensure ollama is serving
+          try {
+            execSync('curl -sf http://localhost:11434/api/tags > /dev/null', { timeout: 3000 });
+          } catch {
+            // Start ollama serve in background
+            execSync('nohup ollama serve > /dev/null 2>&1 &', { shell: '/bin/bash' });
+            // Wait briefly for it to start
+            execSync('sleep 3');
+          }
+
+          execSync('ollama pull nomic-embed-text', {
+            stdio: 'inherit',
+            timeout: 300000, // 5 min for model download
+          });
+          console.log(chalk.green('✅ Embedding model ready\n'));
+        } catch (error) {
+          console.log(chalk.yellow('⚠️  Could not pull embedding model — run manually: ollama pull nomic-embed-text\n'));
+        }
+      }
+    } else {
+      console.log(chalk.gray('⏭️  Skipping Ollama installation (--skip-ollama)\n'));
+    }
+
     // Run doctor unless skipped
     if (!options.skipDoctor) {
       console.log(chalk.cyan('🔍 Running health check...\n'));
       const healthy = await runDoctor();
-      
+
       if (healthy) {
         console.log(chalk.green('\n✅ Zouroboros is ready to use!\n'));
         console.log('Next steps:');

--- a/cli/src/utils/doctor.ts
+++ b/cli/src/utils/doctor.ts
@@ -2,18 +2,19 @@
  * Doctor utility - Health check for Zouroboros components
  */
 
-import { existsSync } from 'fs';
-import { execSync } from 'child_process';
-import { join } from 'path';
+import { existsSync, mkdirSync } from 'fs';
+import { execSync, spawnSync } from 'child_process';
+import { join, dirname } from 'path';
 import { homedir } from 'os';
 import chalk from 'chalk';
-import { loadConfig, DEFAULT_MEMORY_DB_PATH } from 'zouroboros-core';
+import { loadConfig, saveConfig, DEFAULT_CONFIG, DEFAULT_MEMORY_DB_PATH } from 'zouroboros-core';
 
 interface CheckResult {
   name: string;
   status: 'ok' | 'warning' | 'error';
   message: string;
   fixable?: boolean;
+  fix?: () => boolean;
 }
 
 export async function runDoctor(options: { fix?: boolean } = {}): Promise<boolean> {
@@ -24,11 +25,27 @@ export async function runDoctor(options: { fix?: boolean } = {}): Promise<boolea
   if (existsSync(configPath)) {
     checks.push({ name: 'Configuration', status: 'ok', message: `Found at ${configPath}` });
   } else {
-    checks.push({ 
-      name: 'Configuration', 
-      status: 'error', 
+    checks.push({
+      name: 'Configuration',
+      status: 'error',
       message: 'Not found. Run: zouroboros init',
-      fixable: true 
+      fixable: true,
+      fix: () => {
+        try {
+          const configDir = join(homedir(), '.zouroboros');
+          mkdirSync(configDir, { recursive: true });
+          const config = { ...DEFAULT_CONFIG, initializedAt: new Date().toISOString() };
+          saveConfig(config, configPath);
+
+          // Create workspace directories
+          for (const sub of ['logs', 'seeds', 'results']) {
+            mkdirSync(join(configDir, sub), { recursive: true });
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      },
     });
   }
 
@@ -43,31 +60,102 @@ export async function runDoctor(options: { fix?: boolean } = {}): Promise<boolea
       checks.push({ name: 'Memory Database', status: 'warning', message: 'Exists but schema may need migration' });
     }
   } else {
-    checks.push({ 
-      name: 'Memory Database', 
-      status: 'warning', 
+    checks.push({
+      name: 'Memory Database',
+      status: 'warning',
       message: 'Not initialized. Will be created on first use.',
-      fixable: true 
+      fixable: true,
+      fix: () => {
+        try {
+          const dbDir = dirname(memoryDb);
+          mkdirSync(dbDir, { recursive: true });
+
+          const schemaSql = `
+PRAGMA journal_mode = WAL;
+CREATE TABLE IF NOT EXISTS facts (id TEXT PRIMARY KEY, persona TEXT, entity TEXT NOT NULL, key TEXT, value TEXT NOT NULL, text TEXT NOT NULL, category TEXT DEFAULT 'fact', decay_class TEXT DEFAULT 'medium', importance REAL DEFAULT 1.0, source TEXT, created_at INTEGER DEFAULT (strftime('%s','now')), expires_at INTEGER, last_accessed INTEGER DEFAULT (strftime('%s','now')), confidence REAL DEFAULT 1.0, metadata TEXT);
+CREATE TABLE IF NOT EXISTS fact_embeddings (fact_id TEXT PRIMARY KEY REFERENCES facts(id) ON DELETE CASCADE, embedding BLOB NOT NULL, model TEXT DEFAULT 'nomic-embed-text', created_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE TABLE IF NOT EXISTS episodes (id TEXT PRIMARY KEY, summary TEXT NOT NULL, outcome TEXT NOT NULL, happened_at INTEGER NOT NULL, duration_ms INTEGER, procedure_id TEXT, metadata TEXT, created_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE TABLE IF NOT EXISTS episode_entities (episode_id TEXT NOT NULL REFERENCES episodes(id) ON DELETE CASCADE, entity TEXT NOT NULL, PRIMARY KEY (episode_id, entity));
+CREATE TABLE IF NOT EXISTS procedures (id TEXT PRIMARY KEY, name TEXT NOT NULL, version INTEGER DEFAULT 1, steps TEXT NOT NULL, success_count INTEGER DEFAULT 0, failure_count INTEGER DEFAULT 0, evolved_from TEXT, created_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE TABLE IF NOT EXISTS open_loops (id TEXT PRIMARY KEY, summary TEXT NOT NULL, entity TEXT NOT NULL, status TEXT DEFAULT 'open', priority INTEGER DEFAULT 1, created_at INTEGER DEFAULT (strftime('%s','now')), resolved_at INTEGER);
+CREATE TABLE IF NOT EXISTS continuation_context (id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL, last_summary TEXT NOT NULL, open_loop_ids TEXT, entity_stack TEXT, last_agent TEXT, updated_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE TABLE IF NOT EXISTS cognitive_profiles (entity TEXT PRIMARY KEY, traits TEXT, preferences TEXT, interaction_count INTEGER DEFAULT 0, last_interaction INTEGER, created_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE TABLE IF NOT EXISTS _migrations (id INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at INTEGER DEFAULT (strftime('%s','now')));
+CREATE INDEX IF NOT EXISTS idx_facts_entity_key ON facts(entity, key);
+CREATE INDEX IF NOT EXISTS idx_facts_decay ON facts(decay_class, expires_at);
+CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_episodes_happened ON episodes(happened_at);
+CREATE INDEX IF NOT EXISTS idx_episodes_outcome ON episodes(outcome);
+CREATE INDEX IF NOT EXISTS idx_episode_entities ON episode_entities(entity);
+CREATE INDEX IF NOT EXISTS idx_open_loops_entity ON open_loops(entity, status);
+`;
+          execSync(`sqlite3 "${memoryDb}" "${schemaSql.replace(/"/g, '\\"')}"`, {
+            shell: '/bin/bash',
+            stdio: 'pipe',
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      },
     });
   }
 
   // Check 3: Ollama (for embeddings)
+  let ollamaRunning = false;
   try {
-    execSync('curl -s http://localhost:11434/api/tags > /dev/null', { timeout: 5000 });
+    execSync('curl -sf http://localhost:11434/api/tags > /dev/null', { timeout: 5000 });
+    ollamaRunning = true;
     checks.push({ name: 'Ollama', status: 'ok', message: 'Running on localhost:11434' });
   } catch {
-    checks.push({ 
-      name: 'Ollama', 
-      status: 'warning', 
-      message: 'Not running. Vector search will be limited.',
-      fixable: false 
+    // Check if ollama is installed but not running
+    let ollamaInstalled = false;
+    try {
+      execSync('command -v ollama', { stdio: 'pipe' });
+      ollamaInstalled = true;
+    } catch {}
+
+    checks.push({
+      name: 'Ollama',
+      status: 'warning',
+      message: ollamaInstalled
+        ? 'Installed but not running. Start with: ollama serve'
+        : 'Not installed. Vector search will be limited.',
+      fixable: true,
+      fix: () => {
+        try {
+          if (!ollamaInstalled) {
+            console.log(chalk.gray('     Installing Ollama...'));
+            execSync('curl -fsSL https://ollama.com/install.sh | sh', {
+              stdio: 'inherit',
+              timeout: 120000,
+            });
+          }
+
+          // Start ollama serve in background
+          console.log(chalk.gray('     Starting Ollama...'));
+          spawnSync('sh', ['-c', 'nohup ollama serve > /dev/null 2>&1 &'], { stdio: 'ignore' });
+          execSync('sleep 3');
+
+          // Pull embedding model
+          console.log(chalk.gray('     Pulling nomic-embed-text model...'));
+          execSync('ollama pull nomic-embed-text', {
+            stdio: 'inherit',
+            timeout: 300000,
+          });
+
+          return true;
+        } catch {
+          return false;
+        }
+      },
     });
   }
 
   // Check 4: Swarm executors
   const executors = ['claude-code', 'codex', 'gemini', 'hermes'];
   const availableExecutors: string[] = [];
-  
+
   for (const executor of executors) {
     try {
       execSync(`command -v ${executor} > /dev/null 2>&1`);
@@ -78,21 +166,21 @@ export async function runDoctor(options: { fix?: boolean } = {}): Promise<boolea
   }
 
   if (availableExecutors.length > 0) {
-    checks.push({ 
-      name: 'Swarm Executors', 
-      status: 'ok', 
-      message: `${availableExecutors.length} available: ${availableExecutors.join(', ')}` 
+    checks.push({
+      name: 'Swarm Executors',
+      status: 'ok',
+      message: `${availableExecutors.length} available: ${availableExecutors.join(', ')}`
     });
   } else {
-    checks.push({ 
-      name: 'Swarm Executors', 
-      status: 'error', 
+    checks.push({
+      name: 'Swarm Executors',
+      status: 'error',
       message: 'None found. Install at least one: claude-code, codex, gemini, or hermes',
-      fixable: false 
+      fixable: false
     });
   }
 
-  // Check 6: Git
+  // Check 5: Git
   try {
     execSync('command -v git > /dev/null 2>&1');
     checks.push({ name: 'Git', status: 'ok', message: 'Available' });
@@ -103,30 +191,58 @@ export async function runDoctor(options: { fix?: boolean } = {}): Promise<boolea
   // Print results
   console.log('Component Status:');
   console.log('─'.repeat(60));
-  
+
   for (const check of checks) {
-    const icon = check.status === 'ok' ? chalk.green('✓') : 
+    const icon = check.status === 'ok' ? chalk.green('✓') :
                  check.status === 'warning' ? chalk.yellow('⚠') : chalk.red('✗');
     const name = chalk.bold(check.name.padEnd(20));
     const message = check.status === 'error' ? chalk.red(check.message) :
                     check.status === 'warning' ? chalk.yellow(check.message) :
                     chalk.gray(check.message);
-    
+
     console.log(`${icon} ${name} ${message}`);
   }
 
   // Attempt fixes if requested
   if (options.fix) {
-    const fixable = checks.filter(c => c.fixable && c.status !== 'ok');
+    const fixable = checks.filter(c => c.fixable && c.status !== 'ok' && c.fix);
     if (fixable.length > 0) {
       console.log(chalk.cyan('\n🔧 Attempting fixes...\n'));
-      
+
       for (const check of fixable) {
-        console.log(`Fixing ${check.name}...`);
-        // Implementation would go here
+        process.stdout.write(`   Fixing ${check.name}... `);
+        const success = check.fix!();
+        if (success) {
+          console.log(chalk.green('✅ Fixed'));
+        } else {
+          console.log(chalk.red('❌ Failed'));
+        }
       }
+
+      // Re-run health check to show updated status
+      console.log(chalk.cyan('\n🔄 Re-checking...\n'));
+      return runDoctor({ fix: false });
+    } else {
+      console.log(chalk.gray('\nNo fixable issues found.'));
     }
   }
 
-  return checks.every(c => c.status !== 'error');
+  const hasErrors = checks.some(c => c.status === 'error');
+  const hasWarnings = checks.some(c => c.status === 'warning');
+
+  if (hasErrors) {
+    console.log(chalk.red('\n⚠  Some issues found'));
+    if (checks.some(c => c.fixable && c.status !== 'ok')) {
+      console.log(chalk.gray('   Run ' + chalk.yellow('zouroboros doctor --fix') + ' to auto-repair\n'));
+    }
+  } else if (hasWarnings) {
+    console.log(chalk.yellow('\n⚠  Some issues found'));
+    if (checks.some(c => c.fixable && c.status !== 'ok')) {
+      console.log(chalk.gray('   Run ' + chalk.yellow('zouroboros doctor --fix') + ' to auto-repair\n'));
+    }
+  } else {
+    console.log(chalk.green('\n✅ All systems healthy\n'));
+  }
+
+  return !hasErrors;
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -15,7 +15,7 @@ export const ZOUROBOROS_NAME = 'Zouroboros';
 
 export const DEFAULT_WORKSPACE_ROOT = '/home/workspace';
 export const DEFAULT_DATA_DIR = join(homedir(), '.zouroboros');
-export const DEFAULT_CONFIG_DIR = join(homedir(), '.config', 'zouroboros');
+export const DEFAULT_CONFIG_DIR = DEFAULT_DATA_DIR;
 export const DEFAULT_CONFIG_PATH = join(DEFAULT_CONFIG_DIR, 'config.json');
 
 // ============================================================================

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,43 +71,6 @@ fi
 
 echo "✅ Build complete"
 
-# Initialize configuration
-echo ""
-echo "⚙️  Initializing configuration..."
-
-# Create config directory
-mkdir -p "$HOME/.zouroboros"
-
-# Create default config if it doesn't exist
-if [ ! -f "$HOME/.zouroboros/config.yaml" ]; then
-cat > "$HOME/.zouroboros/config.yaml" << 'EOF'
-# Zouroboros Configuration
-
-workspace:
-  path: /home/workspace
-
-memory:
-  dbPath: /home/workspace/.zo/memory/shared-facts.db
-  embeddingModel: nomic-embed-text
-  ollamaUrl: http://localhost:11434
-
-swarm:
-  localConcurrency: 8
-  timeoutSeconds: 600
-  maxRetries: 3
-  routingStrategy: balanced
-
-personas:
-  identityDir: /home/workspace/IDENTITY
-  agencyAgentsDir: /home/workspace/Skills/agency-agents
-
-logging:
-  level: info
-  format: json
-EOF
-    echo "✅ Configuration created at $HOME/.zouroboros/config.yaml"
-fi
-
 # Link CLI globally
 echo ""
 echo "🔗 Linking CLI..."
@@ -118,8 +81,8 @@ if [ -z "${PNPM_HOME:-}" ]; then
     mkdir -p "$PNPM_HOME"
 fi
 
-# Add PNPM_HOME to PATH for this session
-export PATH="$PNPM_HOME:$PATH"
+# Add PNPM_HOME and local bin to PATH for this session
+export PATH="$PNPM_HOME:$HOME/.local/bin:$PATH"
 
 cd "$INSTALL_DIR/cli"
 if pnpm link --global 2>/dev/null; then
@@ -157,14 +120,17 @@ if ! command -v zouroboros &> /dev/null; then
     fi
 fi
 
-# Run health check
+# Run full initialization (config + memory DB + Ollama + health check)
 echo ""
-echo "🏥 Running health check..."
 if command -v zouroboros &> /dev/null; then
-    zouroboros doctor || true
+    zouroboros init --force || true
+elif [ -x "$HOME/.local/bin/zouroboros" ]; then
+    "$HOME/.local/bin/zouroboros" init --force || true
+elif [ -f "$INSTALL_DIR/cli/dist/index.js" ]; then
+    bun "$INSTALL_DIR/cli/dist/index.js" init --force || true
 else
-    echo "⚠️  CLI not in PATH yet. Run 'source ~/.bashrc' or 'source ~/.zshrc' and try:"
-    echo "   zouroboros doctor"
+    echo "⚠️  CLI not found — skipping auto-init."
+    echo "   After adding CLI to PATH, run: zouroboros init"
 fi
 
 # Setup complete
@@ -175,7 +141,7 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 echo "Quick start:"
 echo "  zouroboros doctor         # Check health"
-echo "  zouroboros init           # Initialize project"
+echo "  zouroboros doctor --fix   # Auto-repair issues"
 echo "  zouroboros memory --help  # Memory commands"
 echo "  zouroboros tui            # Launch dashboard"
 echo ""


### PR DESCRIPTION
## Summary
- `install.sh` now runs `zouroboros init` post-build instead of manually creating a YAML config file
- `zouroboros init` creates `config.json`, initializes the SQLite memory DB with full schema, auto-installs Ollama, and pulls the `nomic-embed-text` embedding model
- `zouroboros doctor --fix` implements real auto-repair for all fixable health check items
- Standardized config path to `$HOME/.zouroboros/config.json` (was split between `.zouroboros/` and `.config/zouroboros/`)

## What this fixes
A fresh install previously showed 3 health check warnings/errors:
- ✗ Configuration — "Not found. Run: zouroboros init"
- ⚠ Memory Database — "Not initialized"
- ⚠ Ollama — "Not running"

After this PR, a fresh `curl | bash` install runs `zouroboros init` automatically, producing an all-green health check.

## Test plan
- [ ] Run `curl -fsSL .../install.sh | bash` on a clean system
- [ ] Verify `zouroboros doctor` shows all green
- [ ] Verify `zouroboros doctor --fix` repairs missing components
- [ ] Verify `zouroboros init --skip-ollama` skips Ollama installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)