### PR TITLE
fix(swarm-bench): substitute /tmp/test-project path in test_pass commands

### DIFF
--- a/packages/swarm/scripts/swarm-bench.ts
+++ b/packages/swarm/scripts/swarm-bench.ts
@@ -462,7 +462,8 @@ async function verifyAC(criterion: AcceptanceCriterion, workspacePath: string, o
     
     case "test_pass": {
       const exitCode = await new Promise<number>((resolve) => {
-        const proc = spawn("bash", ["-c", criterion.test_command!], {
+        const cmd = criterion.test_command ?? criterion.command ?? "true";
+        const proc = spawn("bash", ["-c", cmd], {
           cwd: workspacePath,
         });
         proc.on("close", resolve);

--- a/packages/swarm/scripts/swarm-bench.ts
+++ b/packages/swarm/scripts/swarm-bench.ts
@@ -462,7 +462,8 @@ async function verifyAC(criterion: AcceptanceCriterion, workspacePath: string, o
     
     case "test_pass": {
       const exitCode = await new Promise<number>((resolve) => {
-        const cmd = criterion.test_command ?? criterion.command ?? "true";
+        const rawCmd = criterion.test_command ?? criterion.command ?? "true";
+        const cmd = rawCmd.replace(/\/tmp\/test-project/g, workspacePath);
         const proc = spawn("bash", ["-c", cmd], {
           cwd: workspacePath,
         });

--- a/packages/swarm/src/standalone/swarm-bench.ts
+++ b/packages/swarm/src/standalone/swarm-bench.ts
@@ -462,7 +462,8 @@ async function verifyAC(criterion: AcceptanceCriterion, workspacePath: string, o
     
     case "test_pass": {
       const exitCode = await new Promise<number>((resolve) => {
-        const proc = spawn("bash", ["-c", criterion.test_command!], {
+        const cmd = criterion.test_command ?? criterion.command ?? "true";
+        const proc = spawn("bash", ["-c", cmd], {
           cwd: workspacePath,
         });
         proc.on("close", resolve);

--- a/packages/swarm/src/standalone/swarm-bench.ts
+++ b/packages/swarm/src/standalone/swarm-bench.ts
@@ -462,7 +462,8 @@ async function verifyAC(criterion: AcceptanceCriterion, workspacePath: string, o
     
     case "test_pass": {
       const exitCode = await new Promise<number>((resolve) => {
-        const cmd = criterion.test_command ?? criterion.command ?? "true";
+        const rawCmd = criterion.test_command ?? criterion.command ?? "true";
+        const cmd = rawCmd.replace(/\/tmp\/test-project/g, workspacePath);
         const proc = spawn("bash", ["-c", cmd], {
           cwd: workspacePath,
         });


### PR DESCRIPTION
## Summary

The stress-test-v1.json dataset hardcodes /tmp/test-project as the workspace path in test_command strings. The harness creates isolated workspaces at ~/.swarm/bench/results/bench_<id>/ but test_pass was executing commands against /tmp/test-project directly — the actual task files never existed there.

Result: executors correctly wrote files to the bench workspace, but the tests ran against empty /tmp/test-project and failed.

## Fix

```typescript
// BEFORE
const cmd = criterion.test_command ?? criterion.command ?? "true";

// AFTER  
const rawCmd = criterion.test_command ?? criterion.command ?? "true";
const cmd = rawCmd.replace(/\/tmp\/test-project/g, workspacePath);
```

## Impact

This is the second bug found in the same test_pass handler (first was missing command field fallback, now the path substitution). After both fixes, executors that were creating files correctly should now pass test_pass criteria.

Fixed in both locations: packages/swarm/scripts/swarm-bench.ts and packages/swarm/src/standalone/swarm-bench.ts.