### PR TITLE
feat(memory): multi-domain session briefings

### DIFF
--- a/packages/memory/src/standalone/domain-map.ts
+++ b/packages/memory/src/standalone/domain-map.ts
@@ -134,10 +134,25 @@ export const PERSONA_DOMAIN_MAP: Record<string, Domain> = {
 };
 
 /**
+ * Multi-domain personas — these pull briefings from ALL listed domains
+ * instead of a single domain. Used by session-briefing.ts for aggregated context.
+ */
+export const MULTI_DOMAIN_PERSONAS: Record<string, Domain[]> = {
+  "alaric": ["zouroboros", "jhf-trading", "ffb", "infrastructure", "personal"],
+};
+
+/**
  * Look up the domain for a persona slug. Returns "shared" if not mapped.
  */
 export function getPersonaDomain(personaSlug: string): Domain {
   return PERSONA_DOMAIN_MAP[personaSlug] || "shared";
+}
+
+/**
+ * Get all domains for a multi-domain persona. Returns null if single-domain.
+ */
+export function getPersonaDomains(personaSlug: string): Domain[] | null {
+  return MULTI_DOMAIN_PERSONAS[personaSlug] || null;
 }
 
 /**

--- a/packages/memory/src/standalone/memory-gate.ts
+++ b/packages/memory/src/standalone/memory-gate.ts
@@ -16,7 +16,7 @@
 
 import { detectContinuation } from "./continuation";
 import { extractWikilinks } from "./wikilink-utils";
-import { getPersonaDomain } from "./domain-map.ts";
+import { getPersonaDomain, getPersonaDomains } from "./domain-map.ts";
 import { generateBriefing } from "./session-briefing.ts";
 
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
@@ -178,20 +178,26 @@ export async function injectSessionBriefing(personaSlug: string): Promise<string
   // Hermes is excluded at the rule level (omits --persona flag).
 
   try {
-    const domain = getPersonaDomain(personaSlug);
-    const effectiveDomain = domain === "shared" || domain === "personal" ? undefined : domain;
+    // Multi-domain personas (e.g., alaric) pass no domain — generateBriefing
+    // detects the multi-domain config and aggregates across all domains.
+    const multiDomains = getPersonaDomains(personaSlug);
+    let effectiveDomain: string | undefined;
+    if (!multiDomains) {
+      const domain = getPersonaDomain(personaSlug);
+      effectiveDomain = domain === "shared" || domain === "personal" ? undefined : domain;
+    }
+
     const result = await generateBriefing(personaSlug, effectiveDomain);
 
     if (!result.briefing || result.briefing.startsWith("No recent activity")) {
       return null;
     }
 
-    // Set the flag so shouldInjectMemory() skips Tier 3 on the first message
     markBriefingInjected();
 
-    // Format for injection into conversation context
+    const domainLabel = result.domain || effectiveDomain;
     const parts: string[] = [
-      `[Session Briefing — ${personaSlug}${effectiveDomain ? ` (${effectiveDomain})` : ""} — ${result.latency_ms}ms]`,
+      `[Session Briefing — ${personaSlug}${domainLabel ? ` (${domainLabel})` : ""} — ${result.latency_ms}ms]`,
       result.briefing,
     ];
     if (result.active_items.length > 0) {

--- a/packages/memory/src/standalone/session-briefing.ts
+++ b/packages/memory/src/standalone/session-briefing.ts
@@ -16,7 +16,7 @@ import { Database } from "bun:sqlite";
 import { parseArgs } from "util";
 import { loadPersonaContext } from "./vault-persona-loader.ts";
 import { searchCrossPersona, getAccessiblePersonas } from "./cross-persona.ts";
-import { getPersonaDomain } from "./domain-map.ts";
+import { getPersonaDomain, getPersonaDomains } from "./domain-map.ts";
 
 const DB_PATH = process.env.ZO_MEMORY_DB || "/home/workspace/.zo/memory/shared-facts.db";
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://localhost:11434";
@@ -232,7 +232,63 @@ export async function generateBriefing(
 ): Promise<SessionBriefing> {
   const start = performance.now();
 
-  // Auto-resolve domain from persona slug if not provided
+  // Check if this is a multi-domain persona (e.g., alaric)
+  const multiDomains = !domain ? getPersonaDomains(persona) : null;
+
+  if (multiDomains && multiDomains.length > 1) {
+    // Multi-domain briefing: aggregate episodes from all domains, deduplicate
+    const allEpisodes: string[] = [];
+    const allVault: string[] = [];
+    const seenEpisodes = new Set<string>();
+
+    for (const d of multiDomains) {
+      const domainEps = getRecentEpisodes(d, 3);
+      for (const ep of domainEps) {
+        if (!seenEpisodes.has(ep)) {
+          seenEpisodes.add(ep);
+          allEpisodes.push(ep);
+        }
+      }
+      const domainVault = getVaultContext(persona, d);
+      for (const v of domainVault) {
+        if (!allVault.includes(v)) allVault.push(v);
+      }
+    }
+
+    const generalEps = getRecentEpisodes(undefined, 3);
+    for (const ep of generalEps) {
+      if (!seenEpisodes.has(ep)) {
+        seenEpisodes.add(ep);
+        allEpisodes.push(ep);
+      }
+    }
+
+    const openLoops = getOpenLoops(persona);
+    const inheritedFacts = getInheritedFacts(persona, undefined);
+
+    const episodes = allEpisodes.slice(0, 8);
+    const vaultContext = allVault.slice(0, 8);
+    const domainLabel = multiDomains.join("+");
+
+    const briefing = await synthesize(
+      persona, domainLabel, vaultContext, episodes, openLoops, inheritedFacts, maxTokens,
+    );
+
+    const latency_ms = Math.round(performance.now() - start);
+    return {
+      persona,
+      domain: domainLabel,
+      briefing,
+      active_items: openLoops,
+      recent_episodes: episodes,
+      inherited_facts: inheritedFacts,
+      vault_context: vaultContext,
+      generated_at: Math.floor(Date.now() / 1000),
+      latency_ms,
+    };
+  }
+
+  // Single-domain briefing (original path)
   if (!domain) {
     const resolved = getPersonaDomain(persona);
     if (resolved !== "shared" && resolved !== "personal") {
@@ -240,7 +296,6 @@ export async function generateBriefing(
     }
   }
 
-  // Run all data collection in parallel
   const [vaultContext, episodes, openLoops, inheritedFacts] = await Promise.all([
     Promise.resolve(getVaultContext(persona, domain)),
     Promise.resolve(getRecentEpisodes(domain)),
@@ -248,7 +303,6 @@ export async function generateBriefing(
     Promise.resolve(getInheritedFacts(persona, domain)),
   ]);
 
-  // Synthesize
   const briefing = await synthesize(
     persona, domain ?? null, vaultContext, episodes, openLoops, inheritedFacts, maxTokens,
   );


### PR DESCRIPTION
## Summary

Enables cross-domain personas (like alaric) to receive session briefings aggregated across all their domains instead of just their primary domain.

- **domain-map.ts**: Add `MULTI_DOMAIN_PERSONAS` config map and `getPersonaDomains()` export. Alaric configured for `zouroboros+jhf-trading+ffb+infrastructure+personal`.
- **session-briefing.ts**: `generateBriefing()` detects multi-domain personas and aggregates episodes (3/domain, deduped, capped at 8) and vault context across all configured domains before Ollama synthesis.
- **memory-gate.ts**: `injectSessionBriefing()` delegates domain resolution to `generateBriefing()` for multi-domain personas. Also includes the exclusion removal from #46 to keep the branch self-contained.

Closes #44

## Test plan

- [x] `bun test src/` — 68 tests pass, 0 failures
- [x] `tsc --noEmit` — clean
- [ ] Verify alaric briefing shows domain label `zouroboros+jhf-trading+ffb+infrastructure+personal`
- [ ] Verify single-domain personas (e.g., financial-advisor) still get domain-scoped briefings


🤖 Generated with [Claude Code](https://claude.com/claude-code)