### PR TITLE
feat(memory): persona-scoped fact attribution in capture pipeline

### DIFF
--- a/packages/memory/src/standalone/inline-capture.ts
+++ b/packages/memory/src/standalone/inline-capture.ts
@@ -25,6 +25,7 @@ interface InlineOptions {
   source: string;
   captureMode: "inline" | "batch";
   dryRun: boolean;
+  persona: string;
 }
 
 function parseArgs(): InlineOptions {
@@ -34,6 +35,7 @@ function parseArgs(): InlineOptions {
   let source = "inline:unknown";
   let captureMode: "inline" | "batch" = "inline";
   let dryRun = false;
+  let persona = "shared";
 
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -49,6 +51,10 @@ function parseArgs(): InlineOptions {
       case "-s":
         source = args[++i] || source;
         break;
+      case "--persona":
+      case "-p":
+        persona = args[++i] || "shared";
+        break;
       case "--batch":
         captureMode = "batch";
         break;
@@ -58,14 +64,14 @@ function parseArgs(): InlineOptions {
     }
   }
 
-  return { message, context, source, captureMode, dryRun };
+  return { message, context, source, captureMode, dryRun, persona };
 }
 
 async function main() {
   const opts = parseArgs();
 
   if (!opts.message && !opts.context) {
-    console.error("Usage: bun inline-capture.ts --message '...' --context '...' [--source x] [--dry-run]");
+    console.error("Usage: bun inline-capture.ts --message '...' --context '...' [--persona <slug>] [--source x] [--dry-run]");
     process.exit(1);
   }
 
@@ -83,6 +89,7 @@ async function main() {
     source: opts.source,
     captureMode: opts.captureMode,
     dryRun: opts.dryRun,
+    persona: opts.persona,
   });
 
   if (result.stored.length > 0) {

--- a/packages/memory/src/standalone/memory-gate.ts
+++ b/packages/memory/src/standalone/memory-gate.ts
@@ -414,9 +414,10 @@ async function main() {
 
     // Spawn inline-capture detached (survives parent exit)
     const captureSource = `inline:chat/${gate.keywords.join("-")}`;
+    const personaArgs = personaSlug ? ["--persona", personaSlug] : [];
     const captureArgs = conversationContext
-      ? ["bun", INLINE_CAPTURE_SCRIPT, "--message", message, "--context", conversationContext, "--source", captureSource]
-      : ["bun", INLINE_CAPTURE_SCRIPT, "--message", message, "--source", captureSource];
+      ? ["bun", INLINE_CAPTURE_SCRIPT, "--message", message, "--context", conversationContext, "--source", captureSource, ...personaArgs]
+      : ["bun", INLINE_CAPTURE_SCRIPT, "--message", message, "--source", captureSource, ...personaArgs];
 
     const proc = Bun.spawn(captureArgs, {
       stdout: "inherit",


### PR DESCRIPTION
## Problem

All 335 of 337 facts in the DB are tagged `persona='shared'` because the capture pipeline never received or forwarded the persona parameter. This means:
- Persona-specific briefing queries find almost nothing
- The knowledge-promoter's persona-based queries miss 99% of facts

## Fix (PR 3 of 3 in PKA series)

**inline-capture.ts**: Accept `--persona` flag, pass through to `extractAndStoreFacts()`
**memory-gate.ts**: Forward parsed `--persona` slug to inline-capture subprocess spawn

The schema already has the `persona` column with index, and `fact-extractor.ts` already accepts `persona` in `ExtractOptions` — the gap was purely in the CLI wiring between memory-gate → inline-capture → fact-extractor.

## Test

- `bun test` — 742 pass (1 pre-existing failure in errors.test.ts, unrelated)
- Dry-run: `bun inline-capture.ts --message 'test' --persona alaric --dry-run` — accepts and threads persona

## Dependencies

- Depends on #43 (quality gates) ✅ merged
- Depends on #44 (multi-domain briefings) ✅ merged

Closes #45