### PR TITLE
fix(cli): resolve memory CLI via subpath export + add paths.ts tests

### DIFF
--- a/cli/src/commands/memory.ts
+++ b/cli/src/commands/memory.ts
@@ -1,19 +1,61 @@
 import { Command } from 'commander';
 import { spawn } from 'child_process';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
+import { createRequire } from 'module';
+import { existsSync } from 'fs';
+
+const nodeRequire = createRequire(import.meta.url);
 
 /**
- * Monorepo-relative path to the memory package's CLI entry point.
- * Resolves regardless of whether this file is run from source (ts) or
- * built output (dist/cli/src/commands/memory.js).
+ * Locate the memory package's CLI entry point.
+ *
+ * Preference order:
+ *   1. `zouroboros-memory/cli` subpath export — works when this CLI is
+ *      installed as a published npm package alongside `zouroboros-memory`.
+ *   2. Monorepo-relative source path — works when running directly from a
+ *      clone of the repo (dev mode, pre-publish).
+ *
+ * Cached on first successful resolution.
  */
-const MEMORY_CLI = resolve(
-  import.meta.dirname || __dirname,
-  '../../../packages/memory/src/cli.ts'
-);
+let cachedMemoryCli: string | undefined;
+function resolveMemoryCli(): string {
+  if (cachedMemoryCli) return cachedMemoryCli;
+  try {
+    cachedMemoryCli = nodeRequire.resolve('zouroboros-memory/cli');
+    return cachedMemoryCli;
+  } catch {
+    // fall through to monorepo fallback
+  }
+  const monorepoPath = resolve(
+    import.meta.dirname || __dirname,
+    '../../../packages/memory/src/cli.ts'
+  );
+  if (existsSync(monorepoPath)) {
+    cachedMemoryCli = monorepoPath;
+    return cachedMemoryCli;
+  }
+  throw new Error(
+    'Unable to locate zouroboros-memory CLI. Install `zouroboros-memory` or run from a monorepo clone with packages/memory present.'
+  );
+}
 
 function runMemory(args: string[]) {
-  spawn('bun', [MEMORY_CLI, ...args], { stdio: 'inherit' });
+  let target: string;
+  try {
+    target = resolveMemoryCli();
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exitCode = 1;
+    return;
+  }
+  const child = spawn('bun', [target, ...args], { stdio: 'inherit' });
+  child.on('error', (err) => {
+    console.error(`Failed to spawn memory CLI: ${err.message}`);
+    process.exitCode = 1;
+  });
+  child.on('exit', (code) => {
+    if (code && code !== 0) process.exitCode = code;
+  });
 }
 
 export const memoryCommand = new Command('memory')

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  getMemoryDbPath,
+  getCheckpointDir,
+  getWorkspaceRoot,
+  getDataDir,
+  expandHome,
+} from '../paths.js';
+import { DEFAULT_MEMORY_DB_PATH, DEFAULT_DATA_DIR } from '../constants.js';
+
+/**
+ * Snapshot and restore env vars touched by each suite so tests are
+ * independent regardless of the host environment.
+ */
+const ENV_KEYS = [
+  'ZOUROBOROS_MEMORY_DB',
+  'ZO_MEMORY_DB',
+  'ZOUROBOROS_CHECKPOINT_DIR',
+  'ZO_CHECKPOINT_DIR',
+  'ZOUROBOROS_WORKSPACE',
+  'ZO_WORKSPACE',
+  'ZOUROBOROS_DATA_DIR',
+] as const;
+
+let snapshot: Record<string, string | undefined>;
+
+beforeEach(() => {
+  snapshot = {};
+  for (const key of ENV_KEYS) {
+    snapshot[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+});
+
+describe('getMemoryDbPath', () => {
+  test('falls back to DEFAULT_MEMORY_DB_PATH when no env var set', () => {
+    expect(getMemoryDbPath()).toBe(DEFAULT_MEMORY_DB_PATH);
+  });
+
+  test('honors legacy ZO_MEMORY_DB', () => {
+    process.env.ZO_MEMORY_DB = '/custom/legacy.db';
+    expect(getMemoryDbPath()).toBe('/custom/legacy.db');
+  });
+
+  test('honors canonical ZOUROBOROS_MEMORY_DB', () => {
+    process.env.ZOUROBOROS_MEMORY_DB = '/custom/canonical.db';
+    expect(getMemoryDbPath()).toBe('/custom/canonical.db');
+  });
+
+  test('ZOUROBOROS_MEMORY_DB takes precedence over ZO_MEMORY_DB', () => {
+    process.env.ZO_MEMORY_DB = '/legacy.db';
+    process.env.ZOUROBOROS_MEMORY_DB = '/canonical.db';
+    expect(getMemoryDbPath()).toBe('/canonical.db');
+  });
+});
+
+describe('getCheckpointDir', () => {
+  test('falls back to DEFAULT_DATA_DIR/checkpoints', () => {
+    expect(getCheckpointDir()).toBe(join(DEFAULT_DATA_DIR, 'checkpoints'));
+  });
+
+  test('honors legacy ZO_CHECKPOINT_DIR', () => {
+    process.env.ZO_CHECKPOINT_DIR = '/legacy/ckpt';
+    expect(getCheckpointDir()).toBe('/legacy/ckpt');
+  });
+
+  test('ZOUROBOROS_CHECKPOINT_DIR takes precedence', () => {
+    process.env.ZO_CHECKPOINT_DIR = '/legacy/ckpt';
+    process.env.ZOUROBOROS_CHECKPOINT_DIR = '/new/ckpt';
+    expect(getCheckpointDir()).toBe('/new/ckpt');
+  });
+});
+
+describe('getWorkspaceRoot', () => {
+  test('falls back to cwd when no env var set', () => {
+    expect(getWorkspaceRoot()).toBe(process.cwd());
+  });
+
+  test('honors legacy ZO_WORKSPACE', () => {
+    process.env.ZO_WORKSPACE = '/my/ws';
+    expect(getWorkspaceRoot()).toBe('/my/ws');
+  });
+
+  test('ZOUROBOROS_WORKSPACE takes precedence over ZO_WORKSPACE', () => {
+    process.env.ZO_WORKSPACE = '/legacy';
+    process.env.ZOUROBOROS_WORKSPACE = '/canonical';
+    expect(getWorkspaceRoot()).toBe('/canonical');
+  });
+});
+
+describe('getDataDir', () => {
+  test('falls back to DEFAULT_DATA_DIR when no env var set', () => {
+    expect(getDataDir()).toBe(DEFAULT_DATA_DIR);
+  });
+
+  test('honors ZOUROBOROS_DATA_DIR', () => {
+    process.env.ZOUROBOROS_DATA_DIR = '/custom/data';
+    expect(getDataDir()).toBe('/custom/data');
+  });
+});
+
+describe('expandHome', () => {
+  test('returns input unchanged if no leading ~', () => {
+    expect(expandHome('/abs/path')).toBe('/abs/path');
+    expect(expandHome('relative/path')).toBe('relative/path');
+  });
+
+  test('expands bare ~', () => {
+    expect(expandHome('~')).toBe(homedir());
+  });
+
+  test('expands ~/subpath', () => {
+    expect(expandHome('~/foo/bar')).toBe(join(homedir(), 'foo/bar'));
+  });
+
+  test('does not expand ~user (only ~ and ~/)', () => {
+    expect(expandHome('~someuser/foo')).toBe('~someuser/foo');
+  });
+
+  test('handles empty string', () => {
+    expect(expandHome('')).toBe('');
+  });
+});

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" }
+    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
+    "./cli": "./dist/cli.js"
   },
   "files": ["dist/", "README.md"],
   "repository": {


### PR DESCRIPTION
## Summary

Follow-ups to #63 based on the post-merge eval:

1. **CLI resolution hardened for npm install path.** `cli/src/commands/memory.ts` now uses `createRequire` + `zouroboros-memory/cli` subpath export first, falling back to the monorepo-relative source path only when the package isn't installed. Previously the `../../../packages/memory/src/cli.ts` climb only worked in a repo clone — not when Zouroboros is installed as published npm packages.

2. **Spawn error handling.** Added `error` + non-zero exit code propagation to `runMemory()` so failures surface instead of vanishing silently. Dropped unused `join` import.

3. **Subpath export added.** `packages/memory/package.json` exposes `"./cli": "./dist/cli.js"` so consumers can locate the built CLI.

4. **Unit tests for `paths.ts`.** 17 new tests in `packages/core/src/__tests__/paths.test.ts` covering env-var precedence (`ZOUROBOROS_*` > `ZO_*` > default), tilde expansion, and default fallbacks for all five helpers.

## Test plan

- [x] Core tests: 330/330 pass (was 313, +17 new)
- [x] Memory tests: 75/75 pass
- [x] CLI builds clean
- [x] `bun dist/index.js memory --help` lists all subcommands
- [x] Subpath resolution verified via `createRequire().resolve('zouroboros-memory/cli')` under both node and bun → resolves to `packages/memory/dist/cli.js`
- [x] Monorepo fallback verified (triggered when package not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)