### PR TITLE
feat(swarm): MimirTransport for memory-sage role

### DIFF
--- a/packages/swarm/src/__tests__/mimir-transport.test.ts
+++ b/packages/swarm/src/__tests__/mimir-transport.test.ts
@@ -1,0 +1,179 @@
+import { test, expect, describe, mock, beforeAll } from 'bun:test';
+import { MimirTransport } from '../transport/mimir-transport.js';
+import type { Task } from '../types.js';
+import type { TransportOptions } from '../transport/types.js';
+
+function makeTask(taskText: string = 'What do we know about the auth middleware?'): Task {
+  return {
+    id: 'sage-test-1',
+    persona: 'mimir',
+    task: taskText,
+    priority: 'high',
+    role: 'memory-sage',
+  };
+}
+
+const defaultOptions: TransportOptions = { timeoutMs: 15000 };
+
+describe('MimirTransport', () => {
+  test('returns success with synthesis when gate finds context', async () => {
+    // Mock fetch to simulate gate response with synthesis
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/gate')) {
+        return new Response(JSON.stringify({
+          exit_code: 0,
+          method: 'keyword_heuristic',
+          output: '[Mimir Synthesis]\nThe auth middleware was redesigned for compliance in March 2026.',
+          latency_ms: 2500,
+        }), { status: 200 });
+      }
+      return originalFetch(url, init);
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const result = await transport.execute(makeTask(), defaultOptions);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('Mimir Synthesis');
+    expect(result.output).toContain('auth middleware');
+    expect(result.effectiveExecutor).toBe('mimir');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('returns graceful "no context" on exit_code 2 (skip)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({
+        exit_code: 2,
+        method: 'keyword_heuristic',
+        output: '',
+        latency_ms: 5,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const result = await transport.execute(makeTask('hello'), defaultOptions);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('No relevant historical context');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('returns graceful "no context" on exit_code 3 (needed-but-empty)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({
+        exit_code: 3,
+        method: 'ollama_classifier',
+        output: '',
+        latency_ms: 500,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const result = await transport.execute(makeTask('quantum chromodynamics'), defaultOptions);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('No relevant historical context');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('returns failure on HTTP error', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response('Internal Server Error', { status: 500 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const result = await transport.execute(makeTask(), defaultOptions);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('500');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('returns failure on network error', async () => {
+    const transport = new MimirTransport('http://localhost:99999');
+    const result = await transport.execute(makeTask(), { timeoutMs: 2000 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Mimir gate error');
+  });
+
+  test('healthCheck reports mimir backend status', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/health')) {
+        return new Response(JSON.stringify({
+          status: 'ok',
+          backends: {
+            mimir: { exists: true, facts: 705 },
+          },
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const health = await transport.healthCheck();
+
+    expect(health.healthy).toBe(true);
+    expect(health.message).toContain('705 facts');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('healthCheck reports unhealthy when mimir backend missing', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({
+        status: 'ok',
+        backends: {},
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const health = await transport.healthCheck();
+
+    expect(health.healthy).toBe(false);
+    expect(health.message).toContain('not configured');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('executeWithUpdates returns empty updates + result promise', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({
+        exit_code: 0,
+        method: 'keyword_heuristic',
+        output: '[Mimir Synthesis]\nTest synthesis',
+        latency_ms: 100,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const { updates, result } = transport.executeWithUpdates(makeTask(), defaultOptions);
+
+    // Updates should be empty
+    const collected: any[] = [];
+    for await (const u of updates) {
+      collected.push(u);
+    }
+    expect(collected).toHaveLength(0);
+
+    // Result should resolve
+    const r = await result;
+    expect(r.success).toBe(true);
+
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/packages/swarm/src/db/schema.ts
+++ b/packages/swarm/src/db/schema.ts
@@ -104,6 +104,7 @@ function seedDefaultRoles(db: Database): void {
     { id: 'researcher', name: 'Researcher', executor_id: 'hermes', model: null, tags: '["research","web","multi-platform","analysis","investigation"]', description: 'Web research, multi-platform analysis, data gathering' },
     { id: 'junior-developer', name: 'Junior Developer', executor_id: 'gemini', model: 'flash', tags: '["simple","quick","edit","fix"]', description: 'Simple edits, quick fixes, low-complexity tasks' },
     { id: 'ops-engineer', name: 'Ops Engineer', executor_id: 'hermes', model: null, tags: '["infrastructure","deployment","devops","monitoring","chat"]', description: 'Infrastructure, deployment, chat delivery, operations' },
+    { id: 'memory-sage', name: 'Memory Sage (Mimir)', executor_id: 'mimir', model: null, tags: '["memory","context","sage","mimir","recall","history"]', description: 'Queries Mimir for historical context relevant to a task. Injects institutional knowledge into downstream nodes.' },
   ];
 
   const stmt = db.prepare(

--- a/packages/swarm/src/index.ts
+++ b/packages/swarm/src/index.ts
@@ -124,6 +124,9 @@ export type {
 // ACP transport
 export { ACPTransport, type ACPTransportConfig } from './transport/acp-transport.js';
 
+// Mimir transport (memory sage)
+export { MimirTransport } from './transport/mimir-transport.js';
+
 // Heartbeat
 export { HeartbeatScheduler } from './heartbeat/scheduler.js';
 

--- a/packages/swarm/src/transport/factory.ts
+++ b/packages/swarm/src/transport/factory.ts
@@ -9,6 +9,7 @@ import type { ExecutorRegistryEntry } from '../types.js';
 import { CircuitBreaker } from '../circuit/breaker.js';
 import { BridgeTransport } from './bridge-transport.js';
 import { ACPTransport } from './acp-transport.js';
+import { MimirTransport } from './mimir-transport.js';
 import type { ExecutorTransport, TransportType } from './types.js';
 
 /** Per-executor ACP adapter config. */
@@ -27,8 +28,7 @@ export function createTransport(
   entry: ExecutorRegistryEntry,
   circuitBreaker: CircuitBreaker,
 ): ExecutorTransport {
-  const transport: TransportType =
-    (entry as ExecutorRegistryEntry & { transport?: TransportType }).transport ?? 'bridge';
+  const transport: TransportType = entry.transport ?? 'bridge';
 
   switch (transport) {
     case 'bridge':
@@ -45,6 +45,10 @@ export function createTransport(
         adapterBin: spec.bin,
         adapterArgs: spec.args,
       });
+    }
+    case 'mimir': {
+      const gateUrl = process.env.MIMIR_GATE_URL || 'http://localhost:7820';
+      return new MimirTransport(gateUrl);
     }
     default:
       throw new Error(`Unknown transport type '${transport}' for executor '${entry.id}'`);

--- a/packages/swarm/src/transport/mimir-transport.ts
+++ b/packages/swarm/src/transport/mimir-transport.ts
@@ -1,0 +1,132 @@
+/**
+ * MimirTransport — lightweight transport that queries the memory gate's Mimir persona.
+ *
+ * Unlike BridgeTransport/ACPTransport which spawn full LLM sessions, this transport
+ * makes a single HTTP POST to the memory gate daemon. The gate handles retrieval +
+ * Karpathy 2nd Brain synthesis. Typical latency: 2-5s.
+ *
+ * Used by the "memory-sage" role to inject historical context into downstream DAG nodes.
+ */
+
+import type { Task, TaskResult } from '../types.js';
+import type {
+  ExecutorTransport,
+  TransportOptions,
+  SessionUpdate,
+  HealthStatus,
+} from './types.js';
+
+async function* emptyAsyncIterable(): AsyncIterable<SessionUpdate> {}
+
+export class MimirTransport implements ExecutorTransport {
+  private gateUrl: string;
+
+  constructor(gateUrl: string = 'http://localhost:7820') {
+    this.gateUrl = gateUrl;
+  }
+
+  async execute(task: Task, options: TransportOptions): Promise<TaskResult> {
+    const start = Date.now();
+
+    try {
+      const resp = await fetch(`${this.gateUrl}/gate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: task.task, persona: 'mimir' }),
+        signal: AbortSignal.timeout(options.timeoutMs || 15000),
+      });
+
+      if (!resp.ok) {
+        return {
+          task,
+          success: false,
+          error: `Memory gate returned ${resp.status}`,
+          output: '',
+          durationMs: Date.now() - start,
+          retries: 0,
+          effectiveExecutor: 'mimir',
+        };
+      }
+
+      const data = await resp.json() as {
+        exit_code: number;
+        method: string;
+        output: string;
+        latency_ms: number;
+      };
+
+      // exit_code 0 = found context, 2 = skip, 3 = needed-but-empty
+      if (data.exit_code === 0 && data.output) {
+        return {
+          task,
+          success: true,
+          output: data.output,
+          durationMs: Date.now() - start,
+          retries: 0,
+          effectiveExecutor: 'mimir',
+        };
+      }
+
+      // No relevant context — still success (sage has nothing to add)
+      return {
+        task,
+        success: true,
+        output: 'No relevant historical context found for this task.',
+        durationMs: Date.now() - start,
+        retries: 0,
+        effectiveExecutor: 'mimir',
+      };
+    } catch (err) {
+      return {
+        task,
+        success: false,
+        error: `Mimir gate error: ${err}`,
+        output: '',
+        durationMs: Date.now() - start,
+        retries: 0,
+        effectiveExecutor: 'mimir',
+      };
+    }
+  }
+
+  executeWithUpdates(task: Task, options: TransportOptions): {
+    updates: AsyncIterable<SessionUpdate>;
+    result: Promise<TaskResult>;
+  } {
+    return {
+      updates: emptyAsyncIterable(),
+      result: this.execute(task, options),
+    };
+  }
+
+  async healthCheck(): Promise<HealthStatus> {
+    try {
+      const resp = await fetch(`${this.gateUrl}/health`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!resp.ok) {
+        return { healthy: false, message: `Gate returned ${resp.status}` };
+      }
+      const data = await resp.json() as {
+        status: string;
+        backends?: Record<string, { exists: boolean; facts: number }>;
+      };
+
+      const mimirBackend = data.backends?.mimir;
+      if (!mimirBackend || !mimirBackend.exists) {
+        return { healthy: false, message: 'Mimir backend not configured or missing' };
+      }
+
+      return {
+        healthy: true,
+        message: `Gate ok, mimir.db has ${mimirBackend.facts} facts`,
+      };
+    } catch (err) {
+      return { healthy: false, message: `Gate unreachable: ${err}` };
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    // No-op — gate daemon lifecycle managed externally
+  }
+}

--- a/packages/swarm/src/transport/types.ts
+++ b/packages/swarm/src/transport/types.ts
@@ -55,4 +55,4 @@ export interface ExecutorTransport {
   shutdown(): Promise<void>;
 }
 
-export type TransportType = 'bridge' | 'acp';
+export type TransportType = 'bridge' | 'acp' | 'mimir';

--- a/packages/swarm/src/types.ts
+++ b/packages/swarm/src/types.ts
@@ -173,7 +173,7 @@ export interface ExecutorRegistryEntry {
     model?: string;
     envVars?: Record<string, string>;
   };
-  transport?: 'bridge' | 'acp';
+  transport?: 'bridge' | 'acp' | 'mimir';
   capabilities?: ExecutorCapabilities;
   healthCheck?: {
     command: string;


### PR DESCRIPTION
## Summary

Adds **MimirTransport** - a lightweight HTTP transport that queries the memory gate daemon at localhost:7820/gate for Karpathy 2nd Brain synthesis, enabling the new *memory-sage* executor role.

## Changes

- `mimir-transport.ts`: HTTP POST to gate daemon, returns exit_code + output context block. ~2-5s latency vs LLM-based transports. Falls back gracefully when gate unreachable.
- `factory.ts`: Wires `mimir` as a TransportType
- `types.ts`: Adds `mimir` to TransportType union and ExecutorRegistryEntry.transport
- `index.ts`: Exports MimirTransport
- `schema.ts`: Seeds `memory-sage` role (id=mimir) with tags: memory,context,sage,mimir,recall,history
- `__tests__/mimir-transport.test.ts`: Unit tests with mocked gate responses

## Why

Previously, memory context injection required a full LLM session via BridgeTransport. The memory-sage role uses a direct, low-latency query to the already-warm memory gate daemon - faster and cheaper for pure recall tasks.