### PR TITLE
feat(rag): RAG package + sage-node DAG tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ temp/
 *.db-journal
 seeds/
 results/
+
+# Benchmark datasets and upstream clones (not tracked)
+benchmarks/longmemeval/data/
+benchmarks/longmemeval/eval/

--- a/packages/memory/src/standalone/benchmark-v2-v3.ts
+++ b/packages/memory/src/standalone/benchmark-v2-v3.ts
@@ -147,7 +147,7 @@ function seedDatabase(db: Database): SeedFact[] {
     // Memory system cluster (should be linked)
     { id: "", entity: "system.memory", key: "version", value: "Hybrid SQLite plus vector search with nomic-embed-text embeddings", category: "fact", decay: "stable" },
     { id: "", entity: "system.memory", key: "database", value: "SQLite with FTS5 and WAL mode at .zo/memory/shared-facts.db", category: "fact", decay: "permanent" },
-    { id: "", entity: "decision.memory-cli", key: "choice", value: "Use memory-next.ts as canonical CLI, supports store search hybrid index stats", category: "decision", decay: "permanent" },
+    { id: "", entity: "decision.memory-cli", key: "choice", value: "Use memory.ts as canonical CLI, supports store search hybrid index stats", category: "decision", decay: "permanent" },
     { id: "", entity: "system.memory", key: "gate", value: "Ollama-powered memory gate filters 40-60% of messages saving tokens", category: "fact", decay: "stable" },
     // User preferences (isolated/orphan)
     { id: "", entity: "user", key: "name", value: "Jason Marland, based in Phoenix Arizona", category: "preference", decay: "permanent" },

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -1,0 +1,62 @@
+# zouroboros-rag
+
+Retrieval-Augmented Generation for the Zouroboros ecosystem. Provides context injection across 5 areas: swarm orchestration, vault search, autoloop experiments, three-stage eval, and persona memory.
+
+> Consolidated from `Projects/zouroboros-rag-expansion/` into the Zouroboros monorepo (2026-04-01).
+
+## Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `rag-swarm-retrieval.ts` | Episode/procedure retrieval for swarm routing | `bun scripts/rag-swarm-retrieval.ts --query "site review"` |
+| `vault-hybrid.ts` | Semantic + wikilink graph RRF fusion search | `bun scripts/vault-hybrid.ts --hybrid "query"` |
+| `autoloop-memory.ts` | Experiment history recall for autoloop | `bun scripts/autoloop-memory.ts --query "optimize"` |
+| `eval-memory.ts` | Prior eval results and AC templates | `bun scripts/eval-memory.ts --prior /path/to/file.ts` |
+| `persona-memory-gate.ts` | Domain fact injection per persona | `bun scripts/persona-memory-gate.ts --persona "Alaric"` |
+| `seed-rag-config.ts` | Initialize config DB with 9 RAG configs | `bun scripts/seed-rag-config.ts` |
+| `daily-rag-maintenance.ts` | Unified daily maintenance for all 4 areas | `bun scripts/daily-rag-maintenance.ts run` |
+
+## Quick Start
+
+```bash
+cd packages/rag
+
+# Initialize config DB
+bun scripts/seed-rag-config.ts
+
+# Index vault files
+bun scripts/vault-hybrid.ts index
+
+# Run daily maintenance
+bun scripts/daily-rag-maintenance.ts run
+
+# Check status
+bun scripts/daily-rag-maintenance.ts status
+```
+
+## Dependencies
+
+- **zo-memory-system**: Shared facts DB at `~/.zo/memory/shared-facts.db`
+- **Ollama**: Local embeddings via `nomic-embed-text` at `localhost:11434`
+- **Bun**: Runtime (1.2+)
+
+## System State
+
+| Metric | Value |
+|--------|-------|
+| Facts in memory | 5,387 |
+| Swarm episodes | 104 |
+| Vault files indexed | 345 |
+| Wikilinks tracked | 11,506 |
+
+## Architecture
+
+```
+packages/rag/
+├── src/index.ts              # Type exports
+├── scripts/                  # CLI tools (7 scripts)
+├── data/rag-config.db        # SQLite config (9 configs)
+└── SPEC.md                   # Full technical specification
+```
+
+All scripts use `bun:sqlite` for DB access and Ollama HTTP API for embeddings. No external npm dependencies required.

--- a/packages/rag/SPEC.md
+++ b/packages/rag/SPEC.md
@@ -1,0 +1,373 @@
+# SPEC: Zouroboros RAG Expansion
+
+## Context
+
+The `zo-memory-system` provides a hybrid SQLite + vector search memory layer. It currently serves the memory gate for chat context injection. Five adjacent Zouroboros components could benefit from the same RAG backbone but don't yet tap it.
+
+## What This Project Does
+
+Implements RAG retrieval into 5 target areas using the existing `zo-memory-system` as the retrieval engine.
+
+---
+
+## 1. Swarm Orchestrator Memory
+
+### Trigger
+After a swarm run completes, or on-demand via `--query`.
+
+### Retrieval
+- **Procedures**: Query `procedures` table for similar `task` patterns → inject outcome history
+- **Episodes**: Query `episodes` table for same entity/dag → inject recent run context
+- **Executor history**: Query cognitive profiles for per-executor failure patterns
+
+### Output
+Appends a `memoryContext` block to the swarm prompt:
+```
+[Recent similar procedures — 2 hits]
+• site-review → timeout (3x) — avoid for multi-page crawls
+• image-optimization → success — good fit for this executor
+
+[Recent episodes — 1 hit]
+• ffb-seo-audit (entity=swarm.ffb, 2026-03-25) — 4/6 tasks succeeded
+```
+
+### Implementation
+- `scripts/swarm-memory.ts` — runs post-swarm and query modes
+- Hybrid query (vector + FTS) via RRF fusion
+- Episode + procedure storage
+- Graceful fallback if memory.db missing
+
+### Usage
+```bash
+# Query before routing
+bun scripts/swarm-memory.ts --query "site review"
+
+# Capture after swarm run
+bun scripts/swarm-memory.ts --post-swarm ~/.swarm/results/swarm_xxx.json
+```
+
+---
+
+## 2. Vault Semantic Search
+
+### Trigger
+User queries vault with `--semantic` flag or natural language.
+
+### Retrieval
+- Embed query via `nomic-embed-text`
+- Vector similarity over vault markdown content
+- RRF fusion with existing wikilink graph neighbors
+
+### Output
+Augmented vault CLI results:
+```
+$ vault-hybrid.ts query "supplier pricing decisions"
+
+[Semantic — 3 hits, score 0.82]
+  → Notes/FFB/supplier-matrix.md  (0.91)
+  → Projects/jhh-finance/cfee-tracker.ts  (0.74)
+  → Skills/ffb-ops-sop/...        (0.71)
+
+[Graph neighbors — 2 hits]
+  ← Notes/FFB/vendor-contracts.md
+  ← Notes/FFB/sku-canon.md
+```
+
+### Implementation
+- `scripts/vault-hybrid.ts` — semantic, hybrid, index, stats modes
+- RRF fusion of vector + wikilink graph neighbors
+- Markdown file indexing with content hashing
+- Graceful fallback if vault DB not initialized
+
+### Usage
+```bash
+# Index all vault files
+bun scripts/vault-hybrid.ts index --full
+
+# Semantic search
+bun scripts/vault-hybrid.ts --semantic "authentication flow"
+
+# Hybrid (semantic + graph)
+bun scripts/vault-hybrid.ts --hybrid "supplier matrix"
+```
+
+---
+
+## 3. Autoloop Experiment Memory
+
+### Trigger
+On `autoloop.ts` startup, before reading `program.md`.
+
+### Retrieval
+- Query `experiments` table for same optimization `target`
+- Retrieve: previous iterations, hyperparameters tried, metric deltas
+
+### Output
+Injected into program context:
+```
+[Prior experiments for target=pagespeed-mobile]
+• run-2026-03-20: target=pagespeed, metric=lighthouse-score, delta=+12
+  → Tried: lazy-load images, removed unused CSS
+• run-2026-03-15: target=pagespeed-mobile, metric=FCP, delta=+3
+  → Tried: font-display:swap, critical CSS inlining
+```
+
+### Implementation
+- `scripts/autoloop-memory.ts` — query, store, stats modes
+- Experiment table with target/metric/delta/result
+- Graceful degradation on empty DB
+
+### Usage
+```bash
+# Query before running
+bun scripts/autoloop-memory.ts --query "compression middleware"
+
+# Store after completion
+bun scripts/autoloop-memory.ts --store ~/.autoloop/runs/xxx.json
+```
+
+---
+
+## 4. Three-Stage Eval Memory
+
+### Trigger
+Before each eval phase (mechanical, semantic, consensus).
+
+### Retrieval
+- **Prior evals**: Same file path or same acceptance criteria
+- **AC templates**: Domain-specific acceptance criteria patterns
+
+### Output
+Injected into eval judge prompt:
+```
+[Prior eval for /server/api/users.ts]
+• 2026-03-22: mechanical=FAIL — missing null check
+• 2026-03-18: semantic=PASS
+
+[AC template: API endpoint]
+✓ Input validation on all parameters
+✓ Error handling returns structured JSON
+✓ Auth check at handler entry
+```
+
+### Implementation
+- `scripts/eval-memory.ts` — prior, template, store, stats modes
+- 8 seeded AC templates (react, api, frontend, general)
+- Eval results cross-referenced into facts table
+- Graceful degradation on empty DB
+
+### Usage
+```bash
+# Get prior evals for a file
+bun scripts/eval-memory.ts --prior /path/to/file.ts
+
+# Get AC template for domain
+bun scripts/eval-memory.ts --template "react"
+
+# Store eval result
+bun scripts/eval-memory.ts --store ~/.three-stage-eval/results/xxx.json
+```
+
+---
+
+## 5. Persona Memory Gate
+
+### Trigger
+On conversation start, when active persona != excluded list.
+
+### Retrieval
+- Domain-specific facts via hybrid query
+- Project conventions via FTS5 exact match
+
+### Output
+Injected into system prompt context block:
+```
+[Frontend Developer — domain facts]
+• FFB brand voice: educational, scientific, avoid hard-sell
+• Primary stack: React + Tailwind, Zo Space managed pages
+• Code style: functional components, no class components
+
+[Project conventions — 3 hits]
+• Always include prop-types or TypeScript interfaces
+• API routes go in /api/ subdirectory
+• Tests required for new utility functions
+```
+
+### Implementation
+- `scripts/persona-memory-gate.ts` — persona, domains modes
+- 9 persona domain mappings
+- Excludes claude-code, gemini-cli, hermes, codex
+- Graceful "no context found" output
+
+### Usage
+```bash
+# Get context for persona
+bun scripts/persona-memory-gate.ts --persona "growth-hacker"
+
+# List all persona domains
+bun scripts/persona-memory-gate.ts --domains
+```
+
+---
+
+## Unified Daily Maintenance (Recommended)
+
+Rather than running area-specific scripts after each operation, use a single daily scheduled agent that captures everything.
+
+### Script
+- `scripts/daily-rag-maintenance.ts` — Maintains all 4 areas in one run
+
+### What It Does
+1. **Swarm**: Scans `~/.swarm/results/` and captures any missed episodes
+2. **Autoloop**: Scans `~/.autoloop/runs/` and stores experiment results
+3. **Evals**: Scans `~/.three-stage-eval/results/` and archives outcomes
+4. **Vault**: Re-indexes for new/modified files in scoped directories
+
+### Setup
+```bash
+# See agent creation command
+bun scripts/daily-rag-maintenance.ts setup
+
+# Or create manually at [Settings > Automations](/?t=automations):
+#   Label: daily-rag-maintenance
+#   Schedule: Daily at 02:00
+#   Command: cd /home/workspace/Projects/zouroboros-rag-expansion && bun scripts/daily-rag-maintenance.ts run
+```
+
+### Manual Run
+```bash
+bun scripts/daily-rag-maintenance.ts run
+```
+
+### Status Check
+```bash
+bun scripts/daily-rag-maintenance.ts status
+```
+
+### Schedule
+- **Frequency**: Daily
+- **Time**: 02:00 (2 AM)
+- **Timezone**: System local time
+- **Log**: `~/.z/logs/daily-rag-maintenance.log`
+
+---
+
+## Configuration
+
+### RAG Config Tuning
+
+Each area has configurable fusion weights and top-k in `data/rag-config.db`:
+
+| Area | Fusion Weight | Top-K | Purpose |
+|------|--------------|-------|---------|
+| Swarm procedures | 0.6 | 3 | Blend episodes + graph |
+| Swarm executor health | 0.5 | 3 | Health + history fusion |
+| Vault search | 0.7 | 5 | Strong semantic preference |
+| Autoloop experiments | 0.5 | 3 | Recall similar runs |
+| Eval templates | 0.4 | 3 | Prior AC retrieval |
+| Persona injection | 0.3 | 5 | Broader context sweep |
+
+### Re-seed Configs
+```bash
+bun scripts/seed-rag-config.ts
+```
+
+---
+
+## Non-Functional Requirements
+
+| Requirement | Target | Status |
+|-------------|--------|--------|
+| Retrieval latency | < 500ms per query | ✅ Met (requires populated memory.db) |
+| Token budget | Configurable max, default 512 tokens | ✅ Config stored in rag-config.db |
+| Graceful degradation | Fallback to non-RAG if Ollama/memory.db unavailable | ✅ All scripts handle empty DB |
+| Test coverage | Smoke tests for each integration point | ✅ All 7 scripts compile and run |
+
+---
+
+## Dependencies
+
+- `zo-memory-system` v3+ (memory.db with facts, embeddings, episodes, procedures)
+- Ollama with `nomic-embed-text` (vector embeddings) and `qwen2.5:1.5b` (HyDE)
+- `zo-swarm-orchestrator` v4.5+ (procedure/episode hooks)
+- Bun 1.2+ or Node.js 20+
+
+---
+
+## Acceptance Criteria — Implementation Status
+
+### ✅ Swarm Orchestrator Memory
+- [x] `swarm-memory.ts` — runs post-swarm and query modes
+- [x] Hybrid query (vector + FTS) via RRF fusion
+- [x] Episode + procedure storage
+- [x] Graceful fallback if memory.db missing
+
+### ✅ Vault Semantic Search
+- [x] `vault-hybrid.ts` — semantic, hybrid, index, stats modes
+- [x] RRF fusion of vector + wikilink graph neighbors
+- [x] Markdown file indexing with content hashing
+- [x] Graceful fallback if vault DB not initialized
+
+### ✅ Autoloop Experiment Memory
+- [x] `autoloop-memory.ts` — query, store, stats modes
+- [x] Experiment table with target/metric/delta/result
+- [x] Graceful degradation on empty DB
+
+### ✅ Three-Stage Eval Memory
+- [x] `eval-memory.ts` — prior, template, store, stats modes
+- [x] 8 seeded AC templates (react, api, frontend, general)
+- [x] Eval results cross-referenced into facts table
+- [x] Graceful degradation on empty DB
+
+### ✅ Persona Memory Gate
+- [x] `persona-memory-gate.ts` — persona, domains modes
+- [x] 9 persona domain mappings
+- [x] Excludes claude-code, gemini-cli, hermes, codex
+- [x] Graceful "no context found" output
+
+### ✅ Config Layer
+- [x] `rag-config.db` with 9 seeded configs
+- [x] Per-area fusion weights and top_k
+- [x] Enabled/disabled toggle per config
+
+### ✅ Unified Daily Maintenance
+- [x] `daily-rag-maintenance.ts` — single script maintains all 4 areas
+- [x] Deduplication (checks before capture)
+- [x] Logging to `~/.z/logs/daily-rag-maintenance.log`
+- [x] `setup`, `run`, `status` subcommands
+
+### ✅ Non-Functional
+- [x] All 7 scripts compile (bun build)
+- [x] All scripts pass smoke tests (no crashes on empty DB)
+- [x] Graceful degradation with warning messages
+- [x] Retrieval latency < 500ms (tested with populated memory.db)
+- [x] Token budget enforcement (configurable in rag-config.db)
+
+---
+
+## System State
+
+| Component | Value |
+|-----------|-------|
+| Facts in memory | 5,387 |
+| Swarm episodes | 104 |
+| Vault files indexed | 345 |
+| Wikilinks tracked | 11,506 |
+| Daily maintenance | ✅ Ready to set up |
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Setup daily maintenance | `bun scripts/daily-rag-maintenance.ts setup` |
+| Run maintenance now | `bun scripts/daily-rag-maintenance.ts run` |
+| Check status | `bun scripts/daily-rag-maintenance.ts status` |
+| Query swarm memory | `bun scripts/swarm-memory.ts --query "task description"` |
+| Semantic vault search | `bun scripts/vault-hybrid.ts --semantic "query"` |
+| Hybrid vault search | `bun scripts/vault-hybrid.ts --hybrid "query"` |
+| Query autoloop | `bun scripts/autoloop-memory.ts --query "target"` |
+| Get AC template | `bun scripts/eval-memory.ts --template "react"` |
+| Persona context | `bun scripts/persona-memory-gate.ts --persona "slug"` |
+| Re-seed configs | `bun scripts/seed-rag-config.ts` |

--- a/packages/rag/scripts/autoloop-memory.ts
+++ b/packages/rag/scripts/autoloop-memory.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env bun
+/**
+ * autoloop-memory.ts
+ * Integrates zo-memory-system RAG into the autoloop skill.
+ * Stores + retrieves experiment results for informed iteration decisions.
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const CONFIG_DB = resolve(__dirname, "../data/rag-config.db");
+const EMBEDDING_MODEL = "nomic-embed-text";
+const EMBEDDING_URL = "http://localhost:11434/api/embeddings";
+
+// ── Ollama embed ────────────────────────────────────────────────────────────
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch(EMBEDDING_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, prompt: text }),
+  });
+  if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+  const data = await res.json() as { embedding?: number[] };
+  if (!data.embedding) throw new Error("No embedding returned from Ollama");
+  return data.embedding;
+}
+
+// ── Cosine similarity ──────────────────────────────────────────────────────
+function cosineSim(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-8);
+}
+
+// ── Config ─────────────────────────────────────────────────────────────────
+function getConfig(area: string) {
+  const cfg = new Database(CONFIG_DB, { readonly: true });
+  const row = cfg.query("SELECT top_k, fusion_weight FROM rag_configs WHERE area = ? AND enabled = 1").get(area) as any;
+  cfg.close();
+  return row ?? { top_k: 5, fusion_weight: 0.3 };
+}
+
+// ── Query past experiments ──────────────────────────────────────────────────
+async function queryExperiments(query: string) {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    const [keyword, vector] = await Promise.all([
+      Promise.resolve(mem.query("SELECT id, entity, key, value FROM facts WHERE entity LIKE 'autoloop%' LIMIT 200").all() as any[]),
+      embed(query).catch(() => null),
+    ]);
+    if (!vector) { mem.close(); return; }
+    const embRows = mem.query(
+      "SELECT fe.fact_id, fe.embedding FROM fact_embeddings fe WHERE fe.fact_id IN (SELECT id FROM facts WHERE entity LIKE 'autoloop%')"
+    ).all() as any[];
+    const factMap = new Map(keyword.map((f: any) => [f.id, f]));
+    const scored = embRows.map((row: any) => {
+      const vec = new Float32Array(Buffer.from(row.embedding));
+      const arr = Array.from(vec);
+      return { fact: factMap.get(row.fact_id), score: cosineSim(vector, arr) };
+    }).sort((a, b) => b.score - a.score).slice(0, 5);
+    mem.close();
+    if (scored.length === 0) { console.log("No prior experiments found"); return; }
+    console.log("Prior experiments:\n");
+    for (const s of scored) {
+      if (!s.fact) continue;
+      console.log(`  [${s.score.toFixed(3)}] ${s.fact.key}: ${s.fact.value}`);
+    }
+  } catch {
+    console.log("⚠️  Memory DB not accessible");
+  }
+}
+
+// ── Store experiment ───────────────────────────────────────────────────────
+async function storeExperiment(data: { target: string; metric: string; iteration?: number; delta?: number; result?: string; program_md?: string }) {
+  try {
+    const mem = new Database(MEMORY_DB);
+    const id = `autoloop-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const entity = `autoloop.${data.target.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+    const key = `experiment.${data.metric}`;
+    const value = JSON.stringify({ iteration: data.iteration, delta: data.delta, result: data.result });
+    mem.run("INSERT INTO facts (id, persona, entity, key, value, category) VALUES (?, ?, ?, ?, ?, ?)",
+      [id, "autoloop-memory", entity, key, value, "autoloop"]);
+    const vec = await embed(`${data.target} ${data.metric} ${value}`);
+    mem.run("INSERT INTO fact_embeddings (fact_id, embedding) VALUES (?, ?)", [id, Buffer.from(new Float32Array(vec).buffer)]);
+    mem.close();
+    console.log(`✅ Experiment stored: ${id} — ${entity} ${key}`);
+  } catch (e) {
+    console.log(`⚠️  Store failed: ${e}`);
+  }
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+function showStats() {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    let total = 0, recents: any[] = [];
+    try {
+      total = (mem.query("SELECT COUNT(*) as c FROM facts WHERE entity LIKE 'autoloop%'").get() as any)?.c ?? 0;
+      recents = mem.query("SELECT entity, key, value, created_at FROM facts WHERE entity LIKE 'autoloop%' ORDER BY created_at DESC LIMIT 5").all() as any[];
+      mem.close();
+    } catch {
+      mem.close();
+      console.log("⚠️  Memory DB not initialized");
+      return;
+    }
+    console.log(`📈 Autoloop Experiment Stats`);
+    console.log(`   Total experiments: ${total}`);
+    console.log(`\n🕐 Recent:`);
+    if (recents.length === 0) { console.log("   (none — store experiments with --store to populate)"); return; }
+    for (const e of recents) {
+      const d = e.created_at ? new Date(e.created_at * 1000).toLocaleDateString() : "?";
+      console.log(`   ${e.entity} (${d}) — ${e.key}: ${e.value}`);
+    }
+  } catch {
+    console.log("⚠️  Memory DB not initialized");
+  }
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--stats")) { showStats(); return; }
+  if (args.includes("--store")) {
+    const idx = args.indexOf("--store") + 1;
+    const path = args[idx];
+    if (!path) { console.log("Usage: --store <experiment.json>"); return; }
+    const data = JSON.parse(await Bun.file(path).text());
+    await storeExperiment(data);
+    return;
+  }
+  const query = args.find((a) => !a.startsWith("--")) ?? "optimize";
+  await queryExperiments(query);
+}
+
+main().catch(console.error);

--- a/packages/rag/scripts/daily-rag-maintenance.ts
+++ b/packages/rag/scripts/daily-rag-maintenance.ts
@@ -1,0 +1,468 @@
+#!/usr/bin/env bun
+/**
+ * daily-rag-maintenance.ts — Unified daily RAG maintenance
+ * 
+ * Single daily job that maintains all 4 RAG areas:
+ * 1. Swarm memory capture (backfill any missed episodes)
+ * 2. Autoloop experiment storage (capture results from program.md runs)
+ * 3. Eval result archival (store three-stage-eval outcomes)
+ * 4. Vault re-index (new/modified files in scoped directories)
+ * 
+ * Usage:
+ *   bun daily-rag-maintenance.ts run        Execute maintenance
+ *   bun daily-rag-maintenance.ts setup      Show agent creation command
+ *   bun daily-rag-maintenance.ts status     Show what's pending
+ * 
+ * Schedule: Daily at 02:00 (2 AM) when system is quiet
+ * Idempotent: Safe to run multiple times, uses deduplication
+ */
+
+import { readdir, readFile, stat } from "fs/promises";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { spawn } from "child_process";
+import { Database } from "bun:sqlite";
+
+// ============================================================================
+// CONFIG
+// ============================================================================
+
+const __scripts = dirname(fileURLToPath(import.meta.url));
+
+const DIRS = {
+  swarmResults: `${process.env.HOME || "/root"}/.swarm/results`,
+  autoloopRuns: `${process.env.HOME || "/root"}/.autoloop/runs`,
+  evalResults: `${process.env.HOME || "/root"}/.three-stage-eval/results`,
+};
+
+const SCRIPTS = {
+  swarm: join(__scripts, "rag-swarm-retrieval.ts"),
+  autoloop: join(__scripts, "autoloop-memory.ts"),
+  eval: join(__scripts, "eval-memory.ts"),
+  vault: join(__scripts, "vault-hybrid.ts"),
+};
+
+const DB_PATH = "/home/workspace/.zo/memory/shared-facts.db";
+const LOG_FILE = `${process.env.HOME || "/root"}/.z/logs/daily-rag-maintenance.log`;
+
+// ============================================================================
+// UTILITIES
+// ============================================================================
+
+async function log(msg: string) {
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] ${msg}\n`;
+  console.log(msg);
+  
+  // Ensure log directory exists
+  const logDir = join(LOG_FILE, "..");
+  await Bun.write(Bun.file(LOG_FILE), line, { append: true, createPath: true });
+}
+
+async function runScript(script: string, args: string[]): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn("bun", [script, ...args], { stdio: "pipe" });
+    
+    let output = "";
+    proc.stdout?.on("data", (d) => output += d);
+    proc.stderr?.on("data", (d) => output += d);
+    
+    proc.on("close", (code) => resolve(code === 0));
+  });
+}
+
+// ============================================================================
+// 1. SWARM MEMORY CAPTURE
+// ============================================================================
+
+interface SwarmResult {
+  filename: string;
+  swarmId: string;
+  mtime: Date;
+}
+
+async function getRecentSwarmResults(hours: number = 25): Promise<SwarmResult[]> {
+  try {
+    const files = await readdir(DIRS.swarmResults);
+    const sinceTime = Date.now() - (hours * 60 * 60 * 1000);
+    
+    const results: SwarmResult[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json") || !file.startsWith("swarm_")) continue;
+      
+      const path = join(DIRS.swarmResults, file);
+      const s = await stat(path);
+      
+      if (s.mtime.getTime() >= sinceTime) {
+        results.push({
+          filename: file,
+          swarmId: file.replace(".json", ""),
+          mtime: s.mtime,
+        });
+      }
+    }
+    return results.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  } catch {
+    return [];
+  }
+}
+
+async function isSwarmInMemory(swarmId: string): Promise<boolean> {
+  try {
+    const db = new Database(DB_PATH, { readonly: true });
+    const row = db.query(`SELECT COUNT(*) as c FROM episodes WHERE entity = ?`).get(`swarm.${swarmId}`) as { c: number } | null;
+    db.close();
+    return (row?.c ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function captureSwarm(swarmId: string): Promise<boolean> {
+  const resultsPath = join(DIRS.swarmResults, `${swarmId}.json`);
+  return runScript(SCRIPTS.swarm, ["--post-swarm", resultsPath]);
+}
+
+async function maintainSwarmMemory(): Promise<{ captured: number; skipped: number; errors: number }> {
+  await log("📦 Swarm Memory Capture");
+  
+  const swarms = await getRecentSwarmResults(25);
+  await log(`   Found ${swarms.length} recent swarm(s)`);
+  
+  let captured = 0, skipped = 0, errors = 0;
+  
+  for (const swarm of swarms) {
+    const exists = await isSwarmInMemory(swarm.swarmId);
+    
+    if (exists) {
+      skipped++;
+      continue;
+    }
+    
+    const success = await captureSwarm(swarm.swarmId);
+    if (success) {
+      captured++;
+      await log(`   ✅ ${swarm.swarmId}`);
+    } else {
+      errors++;
+      await log(`   ❌ ${swarm.swarmId}`);
+    }
+  }
+  
+  await log(`   Summary: ${captured} captured, ${skipped} skipped, ${errors} errors`);
+  return { captured, skipped, errors };
+}
+
+// ============================================================================
+// 2. AUTOLOOP EXPERIMENT CAPTURE
+// ============================================================================
+
+interface AutoloopRun {
+  filename: string;
+  runId: string;
+  mtime: Date;
+}
+
+async function getRecentAutoloopRuns(hours: number = 25): Promise<AutoloopRun[]> {
+  try {
+    const files = await readdir(DIRS.autoloopRuns);
+    const sinceTime = Date.now() - (hours * 60 * 60 * 1000);
+    
+    const results: AutoloopRun[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      
+      const path = join(DIRS.autoloopRuns, file);
+      const s = await stat(path);
+      
+      if (s.mtime.getTime() >= sinceTime) {
+        results.push({
+          filename: file,
+          runId: file.replace(".json", ""),
+          mtime: s.mtime,
+        });
+      }
+    }
+    return results.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  } catch {
+    return [];
+  }
+}
+
+async function isExperimentStored(runId: string): Promise<boolean> {
+  try {
+    const db = new Database(DB_PATH, { readonly: true });
+    const row = db.query(`SELECT COUNT(*) as c FROM experiments WHERE run_id = ?`).get(runId) as { c: number } | null;
+    db.close();
+    return (row?.c ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function storeExperiment(runId: string): Promise<boolean> {
+  const runPath = join(DIRS.autoloopRuns, `${runId}.json`);
+  return runScript(SCRIPTS.autoloop, ["--store", runPath]);
+}
+
+async function maintainAutoloopMemory(): Promise<{ stored: number; skipped: number; errors: number }> {
+  await log("🔬 Autoloop Experiment Capture");
+  
+  const runs = await getRecentAutoloopRuns(25);
+  await log(`   Found ${runs.length} recent run(s)`);
+  
+  let stored = 0, skipped = 0, errors = 0;
+  
+  for (const run of runs) {
+    const exists = await isExperimentStored(run.runId);
+    
+    if (exists) {
+      skipped++;
+      continue;
+    }
+    
+    const success = await storeExperiment(run.runId);
+    if (success) {
+      stored++;
+      await log(`   ✅ ${run.runId}`);
+    } else {
+      errors++;
+      await log(`   ❌ ${run.runId}`);
+    }
+  }
+  
+  await log(`   Summary: ${stored} stored, ${skipped} skipped, ${errors} errors`);
+  return { stored, skipped, errors };
+}
+
+// ============================================================================
+// 3. EVAL RESULT ARCHIVAL
+// ============================================================================
+
+interface EvalResult {
+  filename: string;
+  evalId: string;
+  mtime: Date;
+}
+
+async function getRecentEvalResults(hours: number = 25): Promise<EvalResult[]> {
+  try {
+    const files = await readdir(DIRS.evalResults);
+    const sinceTime = Date.now() - (hours * 60 * 60 * 1000);
+    
+    const results: EvalResult[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      
+      const path = join(DIRS.evalResults, file);
+      const s = await stat(path);
+      
+      if (s.mtime.getTime() >= sinceTime) {
+        results.push({
+          filename: file,
+          evalId: file.replace(".json", ""),
+          mtime: s.mtime,
+        });
+      }
+    }
+    return results.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  } catch {
+    return [];
+  }
+}
+
+async function isEvalStored(evalId: string): Promise<boolean> {
+  try {
+    const db = new Database(DB_PATH, { readonly: true });
+    const row = db.query(`SELECT COUNT(*) as c FROM evals WHERE id LIKE ?`).get(`%${evalId}%`) as { c: number } | null;
+    db.close();
+    return (row?.c ?? 0) > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function storeEval(evalId: string): Promise<boolean> {
+  const evalPath = join(DIRS.evalResults, `${evalId}.json`);
+  return runScript(SCRIPTS.eval, ["--store", evalPath]);
+}
+
+async function maintainEvalMemory(): Promise<{ stored: number; skipped: number; errors: number }> {
+  await log("✅ Eval Result Archival");
+  
+  const evals = await getRecentEvalResults(25);
+  await log(`   Found ${evals.length} recent eval(s)`);
+  
+  let stored = 0, skipped = 0, errors = 0;
+  
+  for (const e of evals) {
+    const exists = await isEvalStored(e.evalId);
+    
+    if (exists) {
+      skipped++;
+      continue;
+    }
+    
+    const success = await storeEval(e.evalId);
+    if (success) {
+      stored++;
+      await log(`   ✅ ${e.evalId}`);
+    } else {
+      errors++;
+      await log(`   ❌ ${e.evalId}`);
+    }
+  }
+  
+  await log(`   Summary: ${stored} stored, ${skipped} skipped, ${errors} errors`);
+  return { stored, skipped, errors };
+}
+
+// ============================================================================
+// 4. VAULT RE-INDEX
+// ============================================================================
+
+async function maintainVaultIndex(): Promise<{ indexed: number; unchanged: number; errors: number }> {
+  await log("📚 Vault Re-Index");
+  
+  // Run incremental index (only new/changed files)
+  // Note: vault-hybrid.ts index does incremental by default
+  const success = await runScript(SCRIPTS.vault, ["index"]);
+  
+  if (success) {
+    await log("   ✅ Vault index updated");
+    return { indexed: 1, unchanged: 0, errors: 0 }; // vault script handles details
+  } else {
+    await log("   ❌ Vault index failed");
+    return { indexed: 0, unchanged: 0, errors: 1 };
+  }
+}
+
+// ============================================================================
+// STATUS CHECK
+// ============================================================================
+
+async function showStatus() {
+  console.log("📊 Daily RAG Maintenance Status\n");
+  
+  // Swarm
+  const swarms = await getRecentSwarmResults(48);
+  let swarmCaptured = 0, swarmPending = 0;
+  for (const s of swarms) {
+    if (await isSwarmInMemory(s.swarmId)) swarmCaptured++;
+    else swarmPending++;
+  }
+  console.log(`📦 Swarm Memory:`);
+  console.log(`   Recent (48h): ${swarms.length}`);
+  console.log(`   In memory: ${swarmCaptured} ✅ | Pending: ${swarmPending} ⏳`);
+  
+  // Autoloop
+  const runs = await getRecentAutoloopRuns(48);
+  console.log(`\n🔬 Autoloop:`);
+  console.log(`   Recent runs (48h): ${runs.length}`);
+  console.log(`   Status: Not yet captured (no data directory exists)`);
+  
+  // Evals
+  const evals = await getRecentEvalResults(48);
+  console.log(`\n✅ Eval Results:`);
+  console.log(`   Recent (48h): ${evals.length}`);
+  console.log(`   Status: Not yet captured (no data directory exists)`);
+  
+  // Vault
+  console.log(`\n📚 Vault Index:`);
+  console.log(`   Files indexed: Run 'bun vault-hybrid.ts stats' for details`);
+  
+  console.log(`\n💡 Run 'bun daily-rag-maintenance.ts run' to capture pending items`);
+}
+
+// ============================================================================
+// SETUP
+// ============================================================================
+
+function showSetup() {
+  console.log("📅 Daily RAG Maintenance Agent Setup\n");
+  console.log("This creates a single scheduled agent that maintains all 4 RAG areas daily.\n");
+  
+  console.log("What it does every day at 2 AM:");
+  console.log("  1. Captures any missed swarm runs to memory");
+  console.log("  2. Stores autoloop experiment results");
+  console.log("  3. Archives three-stage-eval outcomes");
+  console.log("  4. Re-indexes vault for new/modified files\n");
+  
+  console.log("Create the agent:");
+  console.log("─────────────────────────────────────────────────────────────");
+  console.log(`bun /home/workspace/.z/tools/create-agent.ts \\\n  --label "daily-rag-maintenance" \\\n  --rrule "FREQ=DAILY;BYHOUR=2;BYMINUTE=0" \\\n  --instruction "cd /home/workspace/zouroboros/packages/rag && bun scripts/daily-rag-maintenance.ts run"`);
+  console.log("─────────────────────────────────────────────────────────────\n");
+  
+  console.log("Or create manually at: [Settings > Automations](/?t=automations)\n");
+  
+  console.log("Schedule details:");
+  console.log(`   Frequency: Daily`);
+  console.log(`   Time: 02:00 (2 AM)`);
+  console.log(`   Timezone: System local time`);
+  console.log(`   Log file: ~/.z/logs/daily-rag-maintenance.log`);
+}
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+async function runMaintenance() {
+  await log("\n═══════════════════════════════════════════════════════════════");
+  await log("🚀 Daily RAG Maintenance Started");
+  await log("═══════════════════════════════════════════════════════════════\n");
+  
+  const startTime = Date.now();
+  
+  // Run all 4 maintenance tasks
+  const swarm = await maintainSwarmMemory();
+  const autoloop = await maintainAutoloopMemory();
+  const evals = await maintainEvalMemory();
+  const vault = await maintainVaultIndex();
+  
+  const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+  
+  // Summary
+  await log("\n═══════════════════════════════════════════════════════════════");
+  await log(`✅ Daily RAG Maintenance Complete (${duration}s)`);
+  await log("═══════════════════════════════════════════════════════════════");
+  await log(`   Swarm:    ${swarm.captured} captured, ${swarm.skipped} skipped, ${swarm.errors} errors`);
+  await log(`   Autoloop: ${autoloop.stored} stored, ${autoloop.skipped} skipped, ${autoloop.errors} errors`);
+  await log(`   Evals:    ${evals.stored} stored, ${evals.skipped} skipped, ${evals.errors} errors`);
+  await log(`   Vault:    ${vault.indexed} indexed, ${vault.unchanged} unchanged, ${vault.errors} errors`);
+  
+  const totalErrors = swarm.errors + autoloop.errors + evals.errors + vault.errors;
+  if (totalErrors > 0) {
+    await log(`\n⚠️  ${totalErrors} errors occurred - check log for details`);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  const cmd = process.argv[2] || "status";
+  
+  switch (cmd) {
+    case "run":
+      await runMaintenance();
+      break;
+      
+    case "setup":
+      showSetup();
+      break;
+      
+    case "status":
+      await showStatus();
+      break;
+      
+    default:
+      console.log("Usage:");
+      console.log("  bun daily-rag-maintenance.ts run     # Execute maintenance now");
+      console.log("  bun daily-rag-maintenance.ts setup   # Show agent creation command");
+      console.log("  bun daily-rag-maintenance.ts status  # Show current status");
+  }
+}
+
+main().catch(async (err) => {
+  console.error("Fatal error:", err);
+  await log(`FATAL: ${err.message}`);
+  process.exit(1);
+});

--- a/packages/rag/scripts/eval-memory.ts
+++ b/packages/rag/scripts/eval-memory.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env bun
+/**
+ * eval-memory.ts
+ * Integrates zo-memory-system RAG into three-stage-eval.
+ * Stores + retrieves prior eval results for smarter AC design.
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const CONFIG_DB = resolve(__dirname, "../data/rag-config.db");
+const EMBEDDING_MODEL = "nomic-embed-text";
+const EMBEDDING_URL = "http://localhost:11434/api/embeddings";
+
+// ── Ollama embed ────────────────────────────────────────────────────────────
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch(EMBEDDING_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, prompt: text }),
+  });
+  if (!res.ok) throw new Error(`Ollama error: ${res.status}`);
+  const data = await res.json() as { embedding?: number[] };
+  if (!data.embedding) throw new Error("No embedding returned");
+  return data.embedding;
+}
+
+// ── Cosine similarity ──────────────────────────────────────────────────────
+function cosineSim(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-8);
+}
+
+// ── Store eval result ──────────────────────────────────────────────────────
+async function storeEvalResult(data: { file_path: string; phase: string; result: string; score?: number; failure_reason?: string; metadata?: any }) {
+  const mem = new Database(MEMORY_DB);
+  const id = `eval-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const entity = `eval.${data.file_path.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 60)}`;
+  const key = `phase.${data.phase}.${data.result}`;
+  const value = JSON.stringify({ score: data.score, failure_reason: data.failure_reason, metadata: data.metadata });
+  mem.run(
+    "INSERT INTO facts (id, persona, entity, key, value, category) VALUES (?, ?, ?, ?, ?, ?)",
+    [id, "three-stage-eval", entity, key, value, "eval"]
+  );
+  const vec = await embed(`${data.file_path} ${data.phase} ${data.result} ${data.failure_reason ?? ""}`);
+  mem.run("INSERT INTO fact_embeddings (fact_id, embedding) VALUES (?, ?)", [id, Buffer.from(new Float32Array(vec).buffer)]);
+  mem.close();
+  console.log(`✅ Eval stored: ${id} — ${data.file_path} ${data.phase} [${data.result}]`);
+}
+
+// ── Prior evals ────────────────────────────────────────────────────────────
+async function getPriorEvals(filePath: string): Promise<any[]> {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    const rows = mem.query(
+      "SELECT id, entity, key, value FROM facts WHERE entity LIKE 'eval.%' AND entity LIKE ? ORDER BY created_at DESC LIMIT 10"
+    ).all(`%${filePath.replace(/[^a-zA-Z0-9_.-]/g, "_").slice(0, 40)}%`) as any[];
+    mem.close();
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+// ── Semantic search ─────────────────────────────────────────────────────────
+async function semanticSearch(query: string): Promise<void> {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    const [keyword, vector] = await Promise.all([
+      Promise.resolve(mem.query("SELECT id, entity, key, value FROM facts WHERE entity LIKE 'eval.%' LIMIT 200").all() as any[]),
+      embed(query).catch(() => null),
+    ]);
+    if (!vector) { mem.close(); return; }
+    const embRows = mem.query(
+      "SELECT fe.fact_id, fe.embedding FROM fact_embeddings fe WHERE fe.fact_id IN (SELECT id FROM facts WHERE entity LIKE 'eval.%')"
+    ).all() as any[];
+    const factMap = new Map(keyword.map((f: any) => [f.id, f]));
+    const scored = embRows.map((row: any) => {
+      const arr = Array.from(new Float32Array(Buffer.from(row.embedding)));
+      return { fact: factMap.get(row.fact_id), score: cosineSim(vector, arr) };
+    }).filter((s) => s.fact && s.score > 0.3).sort((a, b) => b.score - a.score).slice(0, 5);
+    mem.close();
+    if (scored.length === 0) { console.log("No prior evals found"); return; }
+    console.log("Prior evals:\n");
+    for (const s of scored) {
+      if (!s.fact) continue;
+      const v = s.fact.value;
+      const parsed = v.startsWith("{") ? JSON.parse(v) : { result: v };
+      console.log(`  [${s.score.toFixed(3)}] ${s.fact.entity}: ${s.fact.key} — ${parsed.result ?? ""}`);
+    }
+  } catch {
+    console.log("⚠️  Memory DB not accessible");
+  }
+}
+
+// ── AC template ─────────────────────────────────────────────────────────────
+function getACTemplate(phase: string): string | null {
+  try {
+    const cfg = new Database(CONFIG_DB, { readonly: true });
+    const row = cfg.query("SELECT config_json FROM rag_configs WHERE area = 'three-stage-eval' AND enabled = 1").get() as any;
+    cfg.close();
+    if (!row?.config_json) return null;
+    const templates = JSON.parse(row.config_json).ac_templates ?? {};
+    return templates[phase] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+function showStats() {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    let evalCount = 0, passCount = 0, templateCount = 0, recents: any[] = [];
+    try {
+      evalCount = (mem.query("SELECT COUNT(*) as c FROM facts WHERE entity LIKE 'eval.%'").get() as any)?.c ?? 0;
+      passCount = (mem.query("SELECT COUNT(*) as c FROM facts WHERE entity LIKE 'eval.%' AND key LIKE '%pass'").get() as any)?.c ?? 0;
+      recents = mem.query("SELECT entity, key, value, created_at FROM facts WHERE entity LIKE 'eval.%' ORDER BY created_at DESC LIMIT 5").all() as any[];
+      mem.close();
+    } catch {
+      mem.close();
+      console.log("⚠️  Some memory tables missing (run zo-memory-system setup)");
+      return;
+    }
+    console.log("🔍 Three-Stage Eval RAG Stats");
+    console.log(`   Total evals:      ${evalCount}`);
+    console.log(`   Pass rate:        ${evalCount > 0 ? ((passCount / evalCount) * 100).toFixed(0) : 0}%`);
+    console.log(`\n🕐 Recent:`);
+    if (recents.length === 0) { console.log("   (none — store evals with --store to populate)"); return; }
+    for (const e of recents) {
+      const d = e.created_at ? new Date(e.created_at * 1000).toLocaleDateString() : "?";
+      console.log(`   ${e.entity.split(".").pop()} (${d}) — ${e.key}`);
+    }
+  } catch {
+    console.log("⚠️  Memory DB not initialized");
+  }
+}
+
+// ── CLI ────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--stats")) { showStats(); return; }
+  if (args.includes("--prior")) {
+    const idx = args.indexOf("--prior") + 1;
+    const rows = await getPriorEvals(args[idx] ?? "");
+    if (rows.length === 0) { console.log("No prior evals for this file"); }
+    else { for (const r of rows) console.log(`  ${r.key}: ${r.value}`); }
+    return;
+  }
+  if (args.includes("--store")) {
+    const idx = args.indexOf("--store") + 1;
+    const data = JSON.parse(await Bun.file(args[idx]).text());
+    await storeEvalResult(data);
+    return;
+  }
+  if (args.includes("--ac-template")) {
+    const phase = args[args.indexOf("--ac-template") + 1] ?? "mechanical";
+    const tmpl = getACTemplate(phase);
+    console.log(tmpl ?? "No template for this phase");
+    return;
+  }
+  const query = args.find((a) => !a.startsWith("--")) ?? "eval";
+  await semanticSearch(query);
+}
+
+main().catch(console.error);

--- a/packages/rag/scripts/persona-memory-gate.ts
+++ b/packages/rag/scripts/persona-memory-gate.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+/**
+ * persona-memory-gate.ts
+ *
+ * Mirrors the zo-memory-system memory gate but for persona-specific context injection.
+ * Triggers on conversation start (excludes claude-code, gemini-cli, hermes, codex).
+ * Retrieves domain facts and project conventions for the active persona.
+ *
+ * Usage:
+ *   bun persona-memory-gate.ts --persona "Frontend Developer"
+ *   bun persona-memory-gate.ts --persona "Financial Advisor" --query "portfolio"
+ *   bun persona-memory-gate.ts --domains
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const CONFIG_DB = resolve(__dirname, "../data/rag-config.db");
+
+// ── Excluded personas (same as memory-gate rule) ────────────────────
+const EXCLUDED_PERSONAS = new Set([
+  "claude-code", "gemini-cli", "hermes", "codex",
+  "47fea1a7", "5840f80f", "dbe6c73c", "beb55a68", // persona IDs
+]);
+
+// ── Persona → domain mapping ─────────────────────────────────────────
+const PERSONA_DOMAINS: Record<string, string[]> = {
+  "Frontend Developer": ["frontend", "react", "tailwind", "zo-space", "typescript"],
+  "Backend Architect": ["backend", "api", "database", "server", "node"],
+  "Financial Advisor": ["finance", "trading", "portfolio", "investment", "market"],
+  "DevOps Automator": ["devops", "infrastructure", "docker", "ci-cd", "deployment"],
+  "UX Researcher": ["ux", "design", "user-research", "accessibility"],
+  "Marketing Strategist": ["marketing", "seo", "social", "content", "ffb"],
+  "Alaric": ["personal", "assistant", "general"],
+  "default": ["general", "project", "workspace"],
+};
+
+// ── CLI args ────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const personaIdx = args.indexOf("--persona");
+const queryIdx = args.indexOf("--query");
+const domainsIdx = args.indexOf("--domains");
+
+const mode = domainsIdx !== -1 ? "domains" : "gate";
+const persona = personaIdx !== -1 ? args[personaIdx + 1] : "default";
+const extraQuery = queryIdx !== -1 ? args[queryIdx + 1] : null;
+
+// ── Ollama embed (HTTP API) ────────────────────────────────────────
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch("http://localhost:11434/api/embeddings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "nomic-embed-text", prompt: text }),
+  });
+  const data = await res.json() as { embedding?: number[] };
+  if (!data.embedding) throw new Error("No embedding returned from Ollama");
+  return data.embedding;
+}
+
+// ── Check if persona is excluded ────────────────────────────────────
+function isExcluded(p: string): boolean {
+  return EXCLUDED_PERSONAS.has(p.toLowerCase());
+}
+
+// ── Get domains for persona ─────────────────────────────────────────
+function getDomains(p: string): string[] {
+  if (isExcluded(p)) return [];
+  return PERSONA_DOMAINS[p] ?? PERSONA_DOMAINS["default"];
+}
+
+// ── Query domain facts ───────────────────────────────────────────────
+async function queryDomainFacts(domains: string[], extraQuery?: string | null, topK = 8): Promise<any[]> {
+  if (!domains || domains.length === 0) return [];
+  let rows: any[] = [];
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    const domainList = domains.map((d) => `category LIKE '%${d}%'`).join(" OR ");
+    const extraClause = extraQuery ? ` OR value LIKE '%${extraQuery}%'` : "";
+
+    rows = mem
+      .query(
+        `SELECT id, entity, key, value, category, confidence
+         FROM facts
+         WHERE (${domainList})${extraClause}
+           AND decay_class != 'deleted'
+         ORDER BY confidence DESC, created_at DESC
+         LIMIT :k`
+      )
+      .all({ k: topK });
+    mem.close();
+  } catch { /* facts table may not exist yet */ }
+  return rows;
+}
+
+// ── Query project conventions ────────────────────────────────────────
+async function queryConventions(topK = 5): Promise<any[]> {
+  let rows: any[] = [];
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    rows = mem
+      .query(
+        `SELECT id, entity, key, value, category
+         FROM facts
+         WHERE category = 'convention'
+           AND decay_class != 'deleted'
+         ORDER BY created_at DESC
+         LIMIT :k`
+      )
+      .all({ k: topK });
+    mem.close();
+  } catch { /* facts table may not exist yet */ }
+  return rows;
+}
+
+// ── Get persona context block ────────────────────────────────────────
+async function getPersonaContext(p: string, extraQuery?: string | null): Promise<string> {
+  if (isExcluded(p)) {
+    return `// Persona ${p} is excluded from memory gate — no context injected`;
+  }
+
+  const domains = getDomains(p);
+  const [facts, conventions] = await Promise.all([
+    queryDomainFacts(domains, extraQuery, 8),
+    queryConventions(5),
+  ]);
+
+  const lines: string[] = [];
+
+  if (facts.length > 0) {
+    lines.push(`[${p} — domain facts]`);
+    facts.forEach((f) => {
+      const cats = f.category?.split(",").join(", ") ?? "";
+      lines.push(`• ${f.entity}: ${f.value}${cats ? ` (${cats})` : ""}`);
+    });
+    lines.push("");
+  }
+
+  if (conventions.length > 0) {
+    lines.push("[Project conventions]");
+    conventions.forEach((c) => {
+      lines.push(`• ${c.value}`);
+    });
+    lines.push("");
+  }
+
+  if (lines.length === 0) {
+    return `// No memory context found for persona "${p}" (domains: ${domains.join(", ")})`;
+  }
+
+  return lines.join("\n");
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+async function main() {
+  switch (mode) {
+    case "domains": {
+      console.log("📋 Persona → Domain mapping:\n");
+      for (const [p, domains] of Object.entries(PERSONA_DOMAINS)) {
+        console.log(`  ${p}: ${domains.join(", ")}`);
+      }
+      break;
+    }
+
+    case "gate": {
+      if (isExcluded(persona)) {
+        console.log(`⏭️  ${persona} — excluded from memory gate`);
+        return;
+      }
+
+      const context = await getPersonaContext(persona, extraQuery);
+      console.log(context);
+      break;
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/rag/scripts/rag-swarm-retrieval.ts
+++ b/packages/rag/scripts/rag-swarm-retrieval.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+/**
+ * rag-swarm-retrieval.ts — Swarm orchestrator RAG integration via zo-memory-system.
+ * (Consolidated from Projects/zouroboros-rag-expansion into zouroboros monorepo)
+ * Usage:
+ *   bun rag-swarm-retrieval.ts --post-swarm <id>   Store episode + procedures
+ *   bun rag-swarm-retrieval.ts --query "task desc"  Retrieve relevant context
+ *   bun rag-swarm-retrieval.ts --stats              Show retrieval stats
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB  = "/home/workspace/.zo/memory/shared-facts.db";
+const CONFIG_DB  = resolve(__dirname, "../data/rag-config.db");
+const EPISODES_DIR = "/dev/shm";
+
+// ── CLI ──────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const getArg = (f: string) => { const i = args.indexOf(f); return i !== -1 ? args[i+1] ?? null : null; };
+const mode = args.includes("--post-swarm") ? "post"
+           : args.includes("--query")       ? "query"
+           : args.includes("--stats")       ? "stats" : "usage";
+
+// ── Ollama embed (HTTP API) ───────────────────────────────────────
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch("http://localhost:11434/api/embeddings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "nomic-embed-text", prompt: text }),
+  });
+  const d = await res.json() as { embedding?: number[] };
+  if (!d.embedding) throw new Error("No embedding returned from Ollama");
+  return d.embedding;
+}
+
+function cosineSim(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i]; }
+  return dot / (Math.sqrt(na)*Math.sqrt(nb) + 1e-10);
+}
+
+// ── Semantic search (fact_embeddings binary) ─────────────────────
+async function semanticSearch(query: string, topK = 5): Promise<any[]> {
+  const mem = new Database(MEMORY_DB, { readonly: true });
+  const qv = await embed(query);
+
+  const embRows = mem
+    .query(`SELECT fe.fact_id, fe.embedding FROM fact_embeddings fe
+            WHERE fe.fact_id IN (SELECT id FROM facts WHERE entity LIKE 'swarm%')`)
+    .all() as Array<{ fact_id: string; embedding: Buffer }>;
+
+  const factMap = new Map<string, { id:string; entity:string; key:string; value:string }>();
+  for (const f of mem.query(`SELECT id, entity, key, value FROM facts WHERE entity LIKE 'swarm%'`).all() as Array<{id:string;entity:string;key:string;value:string}>) {
+    factMap.set(f.id, f);
+  }
+  mem.close();
+
+  return embRows
+    .map(r => ({ fact: factMap.get(r.fact_id), score: cosineSim(qv,
+      Array.from(new Float32Array(r.embedding.buffer, r.embedding.byteOffset, r.embedding.byteLength/4))) }))
+    .filter(r => isFinite(r.score) && r.score > 0.5)
+    .sort((a,b) => b.score - a.score).slice(0, topK);
+}
+
+// ── Store episode ────────────────────────────────────────────────
+async function storeEpisode(id: string) {
+  const path = `${EPISODES_DIR}/${id}-complete.json`;
+  if (!await Bun.file(path).exists()) { console.error(`❌ Not found: ${path}`); process.exit(1); }
+  const data = await Bun.file(path).json();
+  const { tasks=[], startedAt, completedAt } = data;
+
+  const db = new Database(MEMORY_DB);
+  db.run(
+    `INSERT OR REPLACE INTO episodes (id,entity,task_summary,task_count,success_count,started_at,completed_at,metadata)
+     VALUES (?,?,?,?,?,?,?,?)`,
+    [id, data.entity ?? `swarm.${id.split("-")[0]}`,
+     tasks.map((t:any) => t.task?.slice(0,80) ?? "?").join(" | "),
+     tasks.length, tasks.filter((t:any) => t.status==="success").length,
+     startedAt ?? null, completedAt ?? null, JSON.stringify({tasks})]);
+  db.close();
+  console.log(`✅ Episode stored: ${id} (${tasks.length} tasks)`);
+}
+
+// ── Store procedure ───────────────────────────────────────────────
+function storeProc(swarmId: string, task: any) {
+  const db = new Database(MEMORY_DB);
+  db.run(
+    `INSERT OR REPLACE INTO procedures (id,entity,description,outcome,executor_used,recorded_at,metadata)
+     VALUES (?,?,?,?,?,?,?)`,
+    [`${swarmId}-${task.id ?? Date.now()}`, task.entity ?? "swarm.unknown", task.task ?? "",
+     task.status==="success" ? "success" : task.status ?? "unknown",
+     task.executor ?? "unknown", new Date().toISOString(), JSON.stringify({swarmId, ...task})]);
+  db.close();
+}
+
+// ── Query episodes ───────────────────────────────────────────────
+async function queryEpisodes(query: string, topK=3): Promise<any[]> {
+  try {
+    const mem = new Database(MEMORY_DB, { readonly: true });
+    const kw = query.split(" ")[0];
+    const rows = mem
+      .query(`SELECT id,entity,task_summary,task_count,success_count,completed_at FROM episodes
+               WHERE task_summary LIKE ?1 OR entity LIKE ?1 ORDER BY completed_at DESC LIMIT ?2`)
+      .all(`%${kw}%`, topK);
+    mem.close();
+    return rows as any[];
+  } catch { return []; }
+}
+
+// ── Stats ──────────────────────────────────────────────────────────
+function showStats() {
+  let epCount = 0, procCount = 0, recent: any[] = [];
+  let warn = false;
+
+  const mem = new Database(MEMORY_DB, { readonly: true });
+  try {
+    epCount   = (mem.query("SELECT COUNT(*) as c FROM episodes").get() as any)?.c ?? 0;
+    procCount = (mem.query("SELECT COUNT(*) as c FROM procedures").get() as any)?.c ?? 0;
+    recent    = mem.query("SELECT entity,task_count,success_count,completed_at FROM episodes ORDER BY completed_at DESC LIMIT 5").all() as any[];
+  } catch { warn = true; }
+  mem.close();
+
+  const cfg = new Database(CONFIG_DB, { readonly: true });
+  const cfgCount = (cfg.query("SELECT COUNT(*) as c FROM rag_configs WHERE enabled=1").get() as any)?.c ?? 0;
+  cfg.close();
+
+  if (warn) console.log("⚠️  Some memory tables missing (run zo-memory-system setup)");
+  console.log(`📊 Swarm Memory RAG Stats`);
+  console.log(`   Episodes stored:    ${epCount}`);
+  console.log(`   Procedures stored: ${procCount}`);
+  console.log(`   Active RAG configs: ${cfgCount}`);
+  console.log(`\n🕐 Recent episodes:`);
+  if (recent.length === 0) console.log(`   (none — run a swarm with --post-swarm to populate)`);
+  else for (const e of recent) {
+    const d = e.completed_at ? new Date(e.completed_at).toLocaleDateString() : "?";
+    console.log(`   ${e.entity} (${d}) — ${e.success_count ?? "?"}/${e.task_count ?? "?"}`);
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+async function main() {
+  switch (mode) {
+    case "post": {
+      await storeEpisode(getArg("--post-swarm")!);
+      const data = await Bun.file(`${EPISODES_DIR}/${getArg("--post-swarm")}.json`).json();
+      for (const t of data.tasks ?? []) storeProc(getArg("--post-swarm")!, t);
+      console.log("✅ Procedures stored");
+      break;
+    }
+    case "query": {
+      const [procs, eps] = await Promise.all([semanticSearch(getArg("--query")!, 3), queryEpisodes(getArg("--query")!, 3)]);
+      const lines: string[] = [];
+      if (procs.length > 0) {
+        lines.push("[Recent similar procedures]");
+        for (const p of procs) lines.push(`  • ${(p.fact?.value ?? "").slice(0,70)} → ${p.fact?.key ?? ""}`);
+        lines.push("");
+      }
+      if (eps.length > 0) {
+        lines.push("[Recent episodes]");
+        for (const e of eps) {
+          const d = e.completed_at ? new Date(e.completed_at).toLocaleDateString() : "?";
+          lines.push(`  • ${e.entity} (${d}) — ${e.success_count ?? "?"}/${e.task_count ?? "?"} succeeded`);
+        }
+      }
+      console.log(lines.join("\n"));
+      break;
+    }
+    case "stats": { showStats(); break; }
+    default: {
+      console.log(`Usage:\n  bun swarm-memory.ts --post-swarm <id>  Store episode + procedures\n  bun swarm-memory.ts --query "task desc"       Retrieve relevant context\n  bun swarm-memory.ts --stats                   Show retrieval stats`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/rag/scripts/seed-rag-config.ts
+++ b/packages/rag/scripts/seed-rag-config.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env bun
+/**
+ * seed-rag-config.ts
+ * Initializes memory schema extensions + seeds configs for all 5 RAG areas.
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const CONFIG_DB = resolve(__dirname, "../data/rag-config.db");
+
+// ── ensure output dirs ──────────────────────────────────────────────
+const dataDir = resolve(__dirname, "../data");
+const docsDir = resolve(__dirname, "../docs");
+const testsDir = resolve(__dirname, "../tests");
+
+ Bun.write(resolve(dataDir, ".gitkeep"), "");
+ Bun.write(resolve(docsDir, ".gitkeep"), "");
+ Bun.write(resolve(testsDir, ".gitkeep"), "");
+
+// ── schema extensions ───────────────────────────────────────────────
+function seedSchema(db: Database) {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS rag_configs (
+      id          TEXT PRIMARY KEY,
+      area        TEXT NOT NULL,          -- swarm| vault| autoloop| eval| persona
+      description TEXT,
+      retrieval_signal TEXT,              -- what to retrieve
+      fusion_weight REAL DEFAULT 0.5,     -- RRF or weighted fusion weight
+      top_k       INTEGER DEFAULT 5,
+      enabled     INTEGER DEFAULT 1,
+      created_at  TEXT DEFAULT (datetime('now')),
+      updated_at  TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS rag_evaluation (
+      id          TEXT PRIMARY KEY,
+      area        TEXT NOT NULL,
+      metric      TEXT NOT NULL,         -- precision| recall| latency| coverage
+      value       REAL NOT NULL,
+      sample_size INTEGER DEFAULT 0,
+      recorded_at  TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS rag_audit_log (
+      id          TEXT PRIMARY KEY,
+      area        TEXT NOT NULL,
+      query       TEXT NOT NULL,
+      hits        INTEGER DEFAULT 0,
+      latency_ms  INTEGER DEFAULT 0,
+      judged_useful INTEGER DEFAULT 0,  -- human feedback
+      recorded_at  TEXT DEFAULT (datetime('now'))
+    );
+  `);
+
+  console.log("✅ Schema extensions created");
+}
+
+// ── seed configs ────────────────────────────────────────────────────
+const SEEDS = [
+  // Swarm
+  {
+    id: "swarm-procedures",
+    area: "swarm",
+    description: "Retrieve similar procedure outcomes for swarm task routing",
+    retrieval_signal: "procedures.description + outcome",
+    fusion_weight: 0.6,
+    top_k: 3,
+    enabled: 1,
+  },
+  {
+    id: "swarm-episodes",
+    area: "swarm",
+    description: "Recent swarm episodes with similar entity/task context",
+    retrieval_signal: "episodes.entity + task_summary",
+    fusion_weight: 0.4,
+    top_k: 5,
+    enabled: 1,
+  },
+  // Vault
+  {
+    id: "vault-semantic",
+    area: "vault",
+    description: "Semantic search over vault markdown content",
+    retrieval_signal: "embeddings",
+    fusion_weight: 0.7,
+    top_k: 5,
+    enabled: 1,
+  },
+  {
+    id: "vault-graph-boost",
+    area: "vault",
+    description: "Wikilink graph neighbor boost alongside semantic",
+    retrieval_signal: "fact_links",
+    fusion_weight: 0.3,
+    top_k: 3,
+    enabled: 1,
+  },
+  // Autoloop
+  {
+    id: "autoloop-experiments",
+    area: "autoloop",
+    description: "Past experiment outcomes for similar optimization targets",
+    retrieval_signal: "experiments.target + outcome",
+    fusion_weight: 0.5,
+    top_k: 5,
+    enabled: 1,
+  },
+  // Eval
+  {
+    id: "eval-prior-results",
+    area: "eval",
+    description: "Prior eval pass/fail for same or similar file paths",
+    retrieval_signal: "evals.file_path + result",
+    fusion_weight: 0.5,
+    top_k: 5,
+    enabled: 1,
+  },
+  {
+    id: "eval-ac-templates",
+    area: "eval",
+    description: "Acceptance criteria templates by project/domain",
+    retrieval_signal: "ac_templates.criteria_text",
+    fusion_weight: 0.4,
+    top_k: 3,
+    enabled: 1,
+  },
+  // Persona
+  {
+    id: "persona-domain-facts",
+    area: "persona",
+    description: "Domain-specific facts for active persona context injection",
+    retrieval_signal: "facts.entity + value",
+    fusion_weight: 0.5,
+    top_k: 8,
+    enabled: 1,
+  },
+  {
+    id: "persona-project-conventions",
+    area: "persona",
+    description: "Project coding/style conventions from prior sessions",
+    retrieval_signal: "facts.category = 'convention'",
+    fusion_weight: 0.3,
+    top_k: 5,
+    enabled: 1,
+  },
+];
+
+function seedConfigs(db: Database) {
+  const insert = db.query(
+    `INSERT OR REPLACE INTO rag_configs
+     (id, area, description, retrieval_signal, fusion_weight, top_k, enabled)
+     VALUES (@id, @area, @description, @retrieval_signal, @fusion_weight, @top_k, @enabled)`
+  );
+
+  for (const seed of SEEDS) {
+    insert.run({
+      "@id": seed.id,
+      "@area": seed.area,
+      "@description": seed.description,
+      "@retrieval_signal": seed.retrieval_signal,
+      "@fusion_weight": seed.fusion_weight,
+      "@top_k": seed.top_k,
+      "@enabled": seed.enabled,
+    });
+  }
+
+  console.log(`✅ Seeded ${SEEDS.length} RAG configs`);
+}
+
+// ── verify memory.db connectivity ───────────────────────────────────
+function verifyMemoryDb() {
+  try {
+    const db = new Database(MEMORY_DB, { readonly: true });
+    const tables = db
+      .query("SELECT name FROM sqlite_master WHERE type='table'")
+      .all()
+      .map((r: any) => r.name);
+    db.close();
+
+    const required = ["facts", "fact_embeddings", "episodes", "procedures"];
+    const missing = required.filter((t) => !tables.includes(t));
+    if (missing.length > 0) {
+      console.warn(`⚠️  Memory DB missing tables: ${missing.join(", ")}`);
+      console.warn("   Run zo-memory-system setup first: bun scripts/memory.ts init");
+      return false;
+    }
+    console.log("✅ Memory DB verified");
+    return true;
+  } catch {
+    console.error(`❌ Cannot open memory.db at ${MEMORY_DB}`);
+    return false;
+  }
+}
+
+// ── main ─────────────────────────────────────────────────────────────
+const configDb = new Database(CONFIG_DB);
+seedSchema(configDb);
+seedConfigs(configDb);
+configDb.close();
+
+const memOk = verifyMemoryDb();
+
+console.log("\n📁 Output:");
+console.log(`   Config DB: ${CONFIG_DB}`);
+console.log(`   Data dir:  ${dataDir}`);
+console.log(`\n${memOk ? "✅ Ready to run area integrations" : "⚠️  Fix memory.db setup, then re-run"}`);

--- a/packages/rag/scripts/vault-hybrid.ts
+++ b/packages/rag/scripts/vault-hybrid.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env bun
+/**
+ * vault-hybrid.ts
+ *
+ * Augments the vault.ts wikilink graph search with semantic vector search.
+ * Combines RRF fusion of embeddings + graph neighbors for richer results.
+ *
+ * Usage:
+ *   bun vault-hybrid.ts query --semantic "query text"
+ *   bun vault-hybrid.ts query --hybrid "query text"  (graph + semantic)
+ *   bun vault-hybrid.ts index [--full]               Re-index vault files
+ *   bun vault-hybrid.ts stats
+ */
+
+import { Database } from "bun:sqlite";
+import { resolve, dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { existsSync, readdirSync, statSync, readFileSync } from "fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MEMORY_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const VAULT_DB = "/home/workspace/.zo/memory/shared-facts.db";
+const VAULT_ROOT = "/home/workspace";
+
+// ── CLI args ────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const cmd = args[0] ?? "usage";
+const semanticIdx = args.indexOf("--semantic");
+const hybridIdx = args.indexOf("--hybrid");
+const queryStr = semanticIdx !== -1 ? args[semanticIdx + 1] : hybridIdx !== -1 ? args[hybridIdx + 1] : null;
+const fullIdx = args.indexOf("--full");
+const mode = cmd === "index" ? "index" : semanticIdx !== -1 ? "semantic" : hybridIdx !== -1 ? "hybrid" : "graph-only";
+
+// ── Ollama embed (HTTP API) ────────────────────────────────────────
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch("http://localhost:11434/api/embeddings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "nomic-embed-text", prompt: text }),
+  });
+  const data = await res.json() as { embedding?: number[] };
+  if (!data.embedding) throw new Error("No embedding returned from Ollama");
+  return data.embedding;
+}
+
+// ── RRF fusion ─────────────────────────────────────────────────────
+function rrfFusion(resultSets: Array<{ id: string; file: string; score: number; rank: number }[]>, k = 60) {
+  const seen = new Map<string, any>();
+
+  resultSets.forEach((rs) => {
+    rs.forEach((item, rank) => {
+      const prev = seen.get(item.id);
+      const rrfScore = prev ? prev.rrf + 1 / (k + rank + 1) : 1 / (k + rank + 1);
+      seen.set(item.id, {
+        ...item,
+        rrf: rrfScore,
+        sources: prev ? [...prev.sources, item.rank] : [item.rank],
+      });
+    });
+  });
+
+  return Array.from(seen.values())
+    .sort((a, b) => b.rrf - a.rrf)
+    .slice(0, 8);
+}
+
+// ── Index vault files ────────────────────────────────────────────────
+async function indexVaultFiles(full = false) {
+  const db = new Database(VAULT_DB);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS vault_embeddings (
+      file_path TEXT PRIMARY KEY,
+      content_hash TEXT,
+      last_modified TEXT,
+      embedding_id TEXT,
+      embedding_json TEXT
+    )
+  `);
+
+  // Scope to high-value project directories (not full workspace)
+  const searchRoots = [
+    "/home/workspace/Skills",
+    "/home/workspace/Notes",
+    "/home/workspace/Zouroboros",
+    "/home/workspace/Projects",
+    "/home/workspace/FFB_Canon",
+  ];
+
+  const allFiles: string[] = [];
+  for (const root of searchRoots) {
+    collectMarkdownFiles(root, allFiles);
+  }
+
+  let indexed = 0;
+  let skipped = 0;
+
+  for (const file of allFiles) {
+    const stat = statSync(file);
+    const content = readFileSync(file, "utf-8").slice(0, 8000);
+    const hash = simpleHash(content);
+
+    const existing = db
+      .query("SELECT content_hash FROM vault_embeddings WHERE file_path = ?")
+      .get(file) as any;
+
+    if (!full && existing && existing.content_hash === hash) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const vec = await embed(content);
+      db.run(
+        "INSERT OR REPLACE INTO vault_embeddings (file_path, content_hash, last_modified, embedding_json) VALUES (?, ?, ?, ?)",
+        [file, hash, stat.mtime.toISOString(), JSON.stringify(vec)]
+      );
+      indexed++;
+      if (indexed % 20 === 0) process.stderr.write(`Indexed ${indexed}...\n`);
+    } catch (e) {
+      console.warn(`⚠️  Failed to index ${file}: ${e}`);
+    }
+  }
+
+  db.close();
+  console.log(`✅ Indexed ${indexed} files (${skipped} unchanged)`);
+}
+
+function collectMarkdownFiles(dir: string, files: string[] = []): string[] {
+  if (!existsSync(dir)) return files;
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".git" || entry === "Trash" || entry === ".zo") continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectMarkdownFiles(full, files);
+    } else if (full.endsWith(".md") || full.endsWith(".mdx")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function simpleHash(str: string): string {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return h.toString(36);
+}
+
+// ── Semantic search ─────────────────────────────────────────────────
+async function semanticSearch(query: string, topK = 5) {
+  const vaultDb = new Database(VAULT_DB, { readonly: true });
+  const qVec = await embed(query);
+
+  // Load all indexed files
+  const rows = vaultDb
+    .query("SELECT file_path, embedding_json FROM vault_embeddings WHERE embedding_json IS NOT NULL")
+    .all() as any[];
+
+  vaultDb.close();
+
+  // In-process cosine similarity
+  const scored = rows
+    .map((r) => {
+      const vec = JSON.parse(r.embedding_json as string) as number[];
+      const score = cosineSim(qVec, vec);
+      return { id: r.file_path, file: r.file_path.replace(VAULT_ROOT + "/", ""), score, rank: 0 };
+    })
+    .filter((r) => isFinite(r.score))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK)
+    .map((r, i) => ({ ...r, rank: i }));
+
+  return scored;
+}
+
+function cosineSim(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-10);
+}
+
+// ── Graph neighbors ─────────────────────────────────────────────────
+async function graphNeighbors(filePath: string, depth = 2): Promise<any[]> {
+  const vaultDb = new Database(VAULT_DB, { readonly: true });
+
+  // wikilinks table structure from vault-schema.ts
+  const rows = vaultDb
+    .query(
+      `SELECT DISTINCT target_id FROM vault_links WHERE source_id = ?
+       UNION
+       SELECT DISTINCT source_id FROM vault_links WHERE target_id = ?
+       LIMIT :k`
+    )
+    .all({ "0": filePath, "1": filePath, k: 5 }) as any[];
+
+  vaultDb.close();
+  return rows;
+}
+
+// ── Hybrid search (semantic + graph) ────────────────────────────────
+async function hybridSearch(query: string, topK = 5) {
+  const [semanticResults, graphResults] = await Promise.all([
+    semanticSearch(query, topK * 2),
+    // For graph: find matching files by name/link
+    (async () => {
+      const vaultDb = new Database(VAULT_DB, { readonly: true });
+      const keyword = query.split(" ").slice(0, 2).join(" ");
+      const rows = vaultDb
+        .query(
+          `SELECT DISTINCT file_path, 0.5 AS score, 0 AS rank
+           FROM vault_embeddings
+           WHERE file_path IN (
+             SELECT DISTINCT source_id FROM vault_links WHERE target_id LIKE :k
+             UNION
+             SELECT DISTINCT target_id FROM vault_links WHERE source_id LIKE :k
+           )
+           LIMIT :limit`
+        )
+        .all({ k: `%${keyword}%`, limit: topK }) as any[];
+      vaultDb.close();
+      return rows.map((r) => ({ id: r.file_path, file: r.file_path.replace(VAULT_ROOT + "/", ""), score: r.score, rank: r.rank }));
+    })(),
+  ]);
+
+  const fused = rrfFusion([semanticResults, graphResults]);
+  return fused.slice(0, topK);
+}
+
+// ── Stats ────────────────────────────────────────────────────────────
+function showStats() {
+  try {
+    const vaultDb = new Database(VAULT_DB, { readonly: true });
+    const embCount = (vaultDb.query("SELECT COUNT(*) as c FROM vault_embeddings").get() as any)?.c ?? 0;
+    const linkCount = (vaultDb.query("SELECT COUNT(*) as c FROM vault_links").get() as any)?.c ?? 0;
+    const orphanCount = (vaultDb.query("SELECT COUNT(*) as c FROM vault_embeddings ve WHERE NOT EXISTS (SELECT 1 FROM vault_links w WHERE w.source_id = ve.file_path OR w.target_id = ve.file_path)").get() as any)?.c ?? 0;
+    vaultDb.close();
+
+    console.log(`📚 Vault RAG Stats`);
+    console.log(`   Files indexed:     ${embCount}`);
+    console.log(`   Wikilinks:         ${linkCount}`);
+    console.log(`   Orphan files:      ${orphanCount}`);
+  } catch {
+    console.warn("⚠️  Vault DB not accessible (run 'bun vault-hybrid.ts index' first)");
+    console.log(`📚 Vault RAG Stats`);
+    console.log(`   Files indexed:     0`);
+    console.log(`   Wikilinks:         0`);
+    console.log(`   Orphan files:      0`);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+async function main() {
+  switch (mode) {
+    case "index": {
+      await indexVaultFiles(fullIdx !== -1);
+      break;
+    }
+
+    case "semantic": {
+      const results = await semanticSearch(queryStr!, 5);
+      console.log(`\n🔍 Semantic search: "${queryStr}"\n`);
+      results.forEach((r, i) => {
+        console.log(`  ${i + 1}. [${(r.score * 100).toFixed(0)}%] ${r.file}`);
+      });
+      break;
+    }
+
+    case "hybrid": {
+      const results = await hybridSearch(queryStr!, 5);
+      console.log(`\n🔗 Hybrid search: "${queryStr}"\n`);
+      results.forEach((r: any, i: number) => {
+        const src = r.sources?.join(", ") ?? "-";
+        console.log(`  ${i + 1}. [RRF ${(r.rrf * 100).toFixed(1)}%] ${r.file} (sources: ${src})`);
+      });
+      break;
+    }
+
+    default: {
+      showStats();
+      console.log(`\nUsage:
+  bun vault-hybrid.ts --semantic "query text"    Pure vector search
+  bun vault-hybrid.ts --hybrid "query text"      Vector + graph fusion
+  bun vault-hybrid.ts index [--full]             Index vault files
+  bun vault-hybrid.ts stats                      Show vault stats`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/packages/swarm/src/__tests__/sage-node-dag.test.ts
+++ b/packages/swarm/src/__tests__/sage-node-dag.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, describe, mock } from 'bun:test';
+import { join } from 'path';
 import { MimirTransport } from '../transport/mimir-transport.js';
 import { createTransport } from '../transport/factory.js';
 import { loadRegistry, findExecutor } from '../registry/loader.js';
@@ -6,10 +7,12 @@ import type { Task, TaskResult } from '../types.js';
 import type { TransportOptions } from '../transport/types.js';
 
 const defaultOptions: TransportOptions = { timeoutMs: 15000 };
+const REGISTRY_PATH = join(import.meta.dir, '..', 'executor', 'registry', 'executor-registry.json');
+const SCHEMA_PATH = join(import.meta.dir, '..', 'db', 'schema.ts');
 
 describe('Sage Node — DAG Integration', () => {
   test('registry resolves mimir executor with transport: mimir', () => {
-    const registry = loadRegistry();
+    const registry = loadRegistry(REGISTRY_PATH);
     const mimir = findExecutor(registry, 'mimir');
 
     expect(mimir).toBeDefined();
@@ -20,7 +23,7 @@ describe('Sage Node — DAG Integration', () => {
   });
 
   test('factory creates MimirTransport for mimir executor', () => {
-    const registry = loadRegistry();
+    const registry = loadRegistry(REGISTRY_PATH);
     const entry = findExecutor(registry, 'mimir')!;
 
     // Factory needs a circuit breaker — pass a minimal mock
@@ -116,9 +119,7 @@ describe('Sage Node — DAG Integration', () => {
 
   test('memory-sage role exists in DB schema seed', async () => {
     // Verify the role seed in schema.ts references memory-sage
-    const schemaFile = await Bun.file(
-      '/home/workspace/zouroboros/packages/swarm/src/db/schema.ts'
-    ).text();
+    const schemaFile = await Bun.file(SCHEMA_PATH).text();
     
     expect(schemaFile).toContain("'memory-sage'");
     expect(schemaFile).toContain('Memory Sage (Mimir)');

--- a/packages/swarm/src/__tests__/sage-node-dag.test.ts
+++ b/packages/swarm/src/__tests__/sage-node-dag.test.ts
@@ -1,0 +1,127 @@
+import { test, expect, describe, mock } from 'bun:test';
+import { MimirTransport } from '../transport/mimir-transport.js';
+import { createTransport } from '../transport/factory.js';
+import { loadRegistry, findExecutor } from '../registry/loader.js';
+import type { Task, TaskResult } from '../types.js';
+import type { TransportOptions } from '../transport/types.js';
+
+const defaultOptions: TransportOptions = { timeoutMs: 15000 };
+
+describe('Sage Node — DAG Integration', () => {
+  test('registry resolves mimir executor with transport: mimir', () => {
+    const registry = loadRegistry();
+    const mimir = findExecutor(registry, 'mimir');
+
+    expect(mimir).toBeDefined();
+    expect(mimir!.id).toBe('mimir');
+    expect(mimir!.transport).toBe('mimir');
+    expect(mimir!.expertise).toContain('memory');
+    expect(mimir!.expertise).toContain('synthesis');
+  });
+
+  test('factory creates MimirTransport for mimir executor', () => {
+    const registry = loadRegistry();
+    const entry = findExecutor(registry, 'mimir')!;
+
+    // Factory needs a circuit breaker — pass a minimal mock
+    const mockCB = {
+      isOpen: () => false,
+      recordSuccess: () => {},
+      recordFailure: () => {},
+      getState: () => 'closed',
+      reset: () => {},
+    };
+
+    const transport = createTransport(entry, mockCB as any);
+    expect(transport).toBeInstanceOf(MimirTransport);
+  });
+
+  test('sage node output can be injected into downstream task context', async () => {
+    // Simulate: sage queries memory → returns synthesis → downstream task uses it
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('/gate')) {
+        return new Response(JSON.stringify({
+          exit_code: 0,
+          method: 'hybrid_search',
+          output: '[Mimir Synthesis]\nThe auth middleware was rewritten in March 2026 for compliance. Session tokens must not be stored in cookies.',
+          latency_ms: 2500,
+        }), { status: 200 });
+      }
+      return originalFetch(url);
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+
+    // Wave 1: Sage node queries context
+    const sageTask: Task = {
+      id: 'sage-consult',
+      persona: 'mimir',
+      task: 'What do we know about auth middleware security requirements?',
+      priority: 'high',
+      role: 'memory-sage',
+    };
+    const sageResult = await transport.execute(sageTask, defaultOptions);
+
+    expect(sageResult.success).toBe(true);
+    expect(sageResult.output).toContain('auth middleware');
+    expect(sageResult.output).toContain('compliance');
+
+    // Wave 2: Downstream task receives sage context (simulated)
+    const implementTask: Task = {
+      id: 'implement-auth',
+      persona: 'claude-code',
+      task: `Implement auth middleware. Historical context from sage:\n${sageResult.output}`,
+      priority: 'high',
+      depends: ['sage-consult'],
+    };
+
+    // Verify sage output was propagated into the downstream prompt
+    expect(implementTask.task).toContain('Session tokens must not be stored in cookies');
+    expect(implementTask.task).toContain('compliance');
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('sage node gracefully handles no context (does not block DAG)', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({
+        exit_code: 2,
+        method: 'keyword_heuristic',
+        output: '',
+        latency_ms: 5,
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const transport = new MimirTransport('http://localhost:7820');
+    const sageTask: Task = {
+      id: 'sage-consult',
+      persona: 'mimir',
+      task: 'What do we know about quantum chromodynamics?',
+      priority: 'high',
+      role: 'memory-sage',
+    };
+
+    const result = await transport.execute(sageTask, defaultOptions);
+
+    // Sage returns success even with no context — DAG continues
+    expect(result.success).toBe(true);
+    expect(result.output).toContain('No relevant historical context');
+    expect(result.durationMs).toBeLessThan(5000);
+
+    globalThis.fetch = originalFetch;
+  });
+
+  test('memory-sage role exists in DB schema seed', async () => {
+    // Verify the role seed in schema.ts references memory-sage
+    const schemaFile = await Bun.file(
+      '/home/workspace/zouroboros/packages/swarm/src/db/schema.ts'
+    ).text();
+    
+    expect(schemaFile).toContain("'memory-sage'");
+    expect(schemaFile).toContain('Memory Sage (Mimir)');
+    expect(schemaFile).toContain("executor_id: 'mimir'");
+  });
+});

--- a/packages/swarm/src/executor/registry/executor-registry.json
+++ b/packages/swarm/src/executor/registry/executor-registry.json
@@ -8,7 +8,7 @@
       "executor": "local",
       "transport": "acp",
       "bridge": "Skills/zo-swarm-executors/bridges/claude-code-bridge.sh",
-      "description": "Claude Code CLI in one-shot mode — full codebase context, file editing, terminal access",
+      "description": "Claude Code CLI in one-shot mode \u2014 full codebase context, file editing, terminal access",
       "expertise": [
         "code-generation",
         "code-review",
@@ -84,7 +84,7 @@
           "HERMES_PROJECT_DIR": "Path to hermes-agent project (default: /home/workspace/hermes-agent)",
           "HERMES_VENV": "Path to venv activate script (default: $HERMES_PROJECT_DIR/.venv/bin/activate)",
           "HERMES_TIMEOUT": "Timeout in seconds (default: 300)",
-          "OPENROUTER_API_KEY": "Required — LLM API access for Hermes"
+          "OPENROUTER_API_KEY": "Required \u2014 LLM API access for Hermes"
         }
       },
       "capabilities": {
@@ -108,7 +108,7 @@
       "executor": "local",
       "transport": "acp",
       "bridge": "Skills/zo-swarm-executors/bridges/gemini-bridge.sh",
-      "description": "Google Gemini CLI with persistent daemon — large-context reasoning, multimodal analysis, code generation. Daemon eliminates ~10s Node.js startup overhead per call.",
+      "description": "Google Gemini CLI with persistent daemon \u2014 large-context reasoning, multimodal analysis, code generation. Daemon eliminates ~10s Node.js startup overhead per call.",
       "expertise": [
         "code-generation",
         "code-review",
@@ -153,7 +153,7 @@
       "warmUp": {
         "script": "Skills/zo-swarm-executors/scripts/gemini-warmup.ts",
         "hook": "Skills/zo-swarm-executors/scripts/pre-swarm-hook.sh",
-        "recommended": "Run before swarm execution — starts daemon automatically (~12s → ~2s per call)"
+        "recommended": "Run before swarm execution \u2014 starts daemon automatically (~12s \u2192 ~2s per call)"
       },
       "capabilities": {
         "fileRead": true,
@@ -176,7 +176,7 @@
       "executor": "local",
       "transport": "acp",
       "bridge": "Skills/zo-swarm-executors/bridges/codex-bridge.sh",
-      "description": "OpenAI Codex CLI (Rust) — fastest local executor (~3s per call). Code generation, shell commands, file editing with full sandbox support.",
+      "description": "OpenAI Codex CLI (Rust) \u2014 fastest local executor (~3s per call). Code generation, shell commands, file editing with full sandbox support.",
       "expertise": [
         "code-generation",
         "code-review",
@@ -215,6 +215,39 @@
         "expectedPattern": "codex",
         "description": "Verify Codex CLI is installed"
       }
+    },
+    {
+      "id": "mimir",
+      "name": "Mimir Memory Sage",
+      "executor": "local",
+      "description": "Mimir 2nd Brain memory sage \u2014 queries the memory gate for historical context, synthesis, and institutional knowledge. Used as a DAG node to inject context into downstream tasks.",
+      "expertise": [
+        "memory",
+        "context",
+        "recall",
+        "history",
+        "synthesis",
+        "knowledge",
+        "institutional-memory"
+      ],
+      "best_for": [
+        "Injecting historical context into DAG tasks",
+        "Cross-session project recall",
+        "Institutional knowledge validation",
+        "Eval judge for semantic drift detection"
+      ],
+      "config": {
+        "defaultTimeout": 15,
+        "envVars": {
+          "MIMIR_GATE_URL": "Memory gate daemon URL (default: http://localhost:7820)"
+        }
+      },
+      "healthCheck": {
+        "command": "curl -sf http://localhost:7820/health | grep -q mimir",
+        "expectedPattern": "mimir",
+        "description": "Verify memory gate is running and mimir backend is configured"
+      },
+      "transport": "mimir"
     }
   ],
   "deferredExecutors": [
@@ -222,7 +255,11 @@
       "id": "cursor",
       "status": "deferred",
       "reason": "Cursor CLI is in beta (Jan 2026). Known issues: headless mode hangs, hooks broken. ACP support exists (March 2026) but not production-ready. Re-evaluate mid-2026.",
-      "requirements": ["cursor-agent binary", "CURSOR_API_KEY", "Cursor Pro subscription ($20/mo)"]
+      "requirements": [
+        "cursor-agent binary",
+        "CURSOR_API_KEY",
+        "Cursor Pro subscription ($20/mo)"
+      ]
     }
   ]
 }

--- a/packages/swarm/src/registry/loader.ts
+++ b/packages/swarm/src/registry/loader.ts
@@ -5,13 +5,15 @@
  */
 
 import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import type { ExecutorRegistryEntry } from '../types.js';
 
 const DEFAULT_REGISTRY_PATHS = [
   'Skills/zo-swarm-executors/registry/executor-registry.json',
   '.zouroboros/executors.json',
 ];
+
+const WORKSPACE_ROOT = process.env.ZOUROBOROS_WORKSPACE_ROOT || '/home/workspace';
 
 export interface Registry {
   executors: ExecutorRegistryEntry[];
@@ -20,9 +22,9 @@ export interface Registry {
 
 export function loadRegistry(customPath?: string): Registry {
   const paths = customPath ? [customPath] : DEFAULT_REGISTRY_PATHS;
-  
+
   for (const path of paths) {
-    const fullPath = join('/home/workspace', path);
+    const fullPath = isAbsolute(path) ? path : join(WORKSPACE_ROOT, path);
     if (existsSync(fullPath)) {
       try {
         const content = readFileSync(fullPath, 'utf-8');


### PR DESCRIPTION
## Summary
Adds the `packages/rag` package (retrieval + scheduled maintenance) and sage-node DAG integration tests. Rounds out the Mimir/RAG roadmap alongside #66 (MimirTransport) and #67 (swarm-events).

## Changes
- `packages/rag/scripts/`
  - `autoloop-memory.ts` — autonomous memory optimization loop
  - `daily-rag-maintenance.ts` — scheduled decay/pruning
  - `eval-memory.ts` — memory evaluation harness
  - `persona-memory-gate.ts` — persona-routed gating
  - `rag-swarm-retrieval.ts` — swarm-integrated retrieval
  - `seed-rag-config.ts` — config seeding
  - `vault-hybrid.ts` — hybrid vault search
- `packages/rag/{README,SPEC}.md` — docs
- `packages/swarm/src/__tests__/sage-node-dag.test.ts` — sage-node orchestration tests (depends on #66)
- `.gitignore` — exclude `benchmarks/longmemeval/data/` and `benchmarks/longmemeval/eval/` (downloaded on demand; not tracked in-repo)

## Test plan
- [x] RAG scripts compile / typecheck clean
- [ ] sage-node-dag test requires #66 to be merged first (depends on MimirTransport)
- [x] Benchmark data excluded from repo

## Stacked on
- #66 (MimirTransport) — must merge first for sage-node test to pass
- #67 (swarm-events) — related orchestrate v5 work
