### PR TITLE
ci: reference upstream bun issue in pin comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
           # Pinned to avoid flakes from unvetted bun releases.
           # 1.3.13 has a parallel module-loader race that mis-reports
           # "Export named 'X' not found" during test parse. 1.3.12 is stable.
-          # Bump intentionally after verifying the test runner is stable.
+          # Upstream: https://github.com/oven-sh/bun/issues/29576
+          # Bump intentionally after the upstream fix lands and we re-verify.
           bun-version: 1.3.12
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Adds `Upstream: https://github.com/oven-sh/bun/issues/29576` to the `setup-bun@v2` pin comment in `ci.yml`
- Changes the "bump intentionally after verifying the test runner is stable" note to "bump intentionally after the upstream fix lands and we re-verify"

## Context
Follow-up to the 1.3.13 test-parse flake we hit on 2026-04-21 (fixed by pinning to 1.3.12 in #80). Now that upstream issue `oven-sh/bun#29576` is filed with a minimal repro, linking it from the workflow so a future maintainer can quickly tell whether the pin is still needed.

No build or test impact — comment-only change.

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)