### PR TITLE
[codex] Harden Mimir capture defaults, clarify agent sync, and add RAG telemetry

### DIFF
--- a/Skills/zouroboros/skills/memory/SKILL.md
+++ b/Skills/zouroboros/skills/memory/SKILL.md
@@ -343,11 +343,14 @@ Extends memory capture beyond swarm tasks to **all conversations**. Scans worksp
 # List all capturable artifacts
 bun scripts/conversation-capture.ts --list
 
-# Process all new artifacts
+# Process last 24h (safe default)
 bun scripts/conversation-capture.ts
 
 # Only last 24 hours
 bun scripts/conversation-capture.ts --since 24h
+
+# Explicit full backlog sweep
+bun scripts/conversation-capture.ts --all
 
 # Preview without storing
 bun scripts/conversation-capture.ts --dry-run
@@ -360,7 +363,8 @@ bun scripts/conversation-capture.ts --stats
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--since <duration>` | Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m | all |
+| `--since <duration>` | Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m | 24h |
+| `--all` | Process all uncaptured artifacts across all conversations | false |
 | `--dry-run` | Show extraction without storing | false |
 | `--list` | List capturable files with status | — |
 | `--stats` | Show conversation capture statistics | — |
@@ -372,6 +376,7 @@ bun scripts/conversation-capture.ts --stats
 - Only processes `.md`, `.txt`, `.json` files
 - Hash-based dedup via `capture_log` table (never re-processes same content)
 - Creates episodes for each capture session
+- Bare invocation is intentionally bounded to the last 24 hours; use `--all` only for an explicit backlog sweep
 
 ### Scheduled Agent
 

--- a/Skills/zouroboros/skills/memory/scripts/conversation-capture.ts
+++ b/Skills/zouroboros/skills/memory/scripts/conversation-capture.ts
@@ -9,9 +9,10 @@
  * This extends memory capture beyond swarm tasks to ALL conversations.
  *
  * Usage:
- *   bun conversation-capture.ts                    # Process all new artifacts
+ *   bun conversation-capture.ts                    # Process last 24h (safe default)
  *   bun conversation-capture.ts --since 24h        # Only last 24 hours
  *   bun conversation-capture.ts --since 7d         # Only last 7 days
+ *   bun conversation-capture.ts --all              # Process all uncaptured artifacts
  *   bun conversation-capture.ts --dry-run           # Preview without storing
  *   bun conversation-capture.ts --stats             # Show capture statistics
  *   bun conversation-capture.ts --list              # List capturable files
@@ -583,15 +584,17 @@ async function main() {
 conversation-capture — Workspace Artifact Memory Capture
 
 Usage:
-  bun conversation-capture.ts                    # Process all new artifacts
+  bun conversation-capture.ts                    # Process last 24h (safe default)
   bun conversation-capture.ts --since 24h        # Only last 24 hours
   bun conversation-capture.ts --since 7d         # Only last 7 days
-  bun conversation-capture.ts --dry-run           # Preview without storing
-  bun conversation-capture.ts --stats             # Show capture statistics
-  bun conversation-capture.ts --list              # List capturable files
+  bun conversation-capture.ts --all              # Process all uncaptured artifacts
+  bun conversation-capture.ts --dry-run          # Preview without storing
+  bun conversation-capture.ts --stats            # Show capture statistics
+  bun conversation-capture.ts --list             # List capturable files
 
 Options:
   --since <duration>   Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m
+  --all                Process all uncaptured artifacts across all conversations
   --dry-run            Show extracted facts without storing
   --stats              Show capture statistics
   --list               List capturable artifact files
@@ -605,9 +608,19 @@ Options:
   }
 
   const dryRun = args.includes("--dry-run");
+  const captureAll = args.includes("--all");
   let sinceDate: Date | undefined;
   const sinceIdx = args.indexOf("--since");
   if (sinceIdx >= 0 && args[sinceIdx + 1]) sinceDate = parseSince(args[sinceIdx + 1]);
+
+  if (captureAll && sinceDate) {
+    console.error("Use either --all or --since <duration>, not both.");
+    process.exit(1);
+  }
+
+  if (!captureAll && !sinceDate) {
+    sinceDate = parseSince("24h");
+  }
 
   if (args.includes("--list") || args[0] === "list") {
     listArtifacts(sinceDate);
@@ -633,7 +646,7 @@ Options:
     process.exit(0);
   }
 
-  console.log(`Found ${newArtifacts.length} new artifacts to capture${sinceDate ? ` (since ${sinceDate.toISOString().slice(0, 10)})` : ""}`);
+  console.log(`Found ${newArtifacts.length} new artifacts to capture${captureAll ? " (full backlog sweep)" : sinceDate ? ` (since ${sinceDate.toISOString().slice(0, 10)})` : ""}`);
   console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}\n`);
 
   await processArtifacts(newArtifacts, dryRun);

--- a/agents/README.md
+++ b/agents/README.md
@@ -2,7 +2,7 @@
 
 Declarative specs for the Zo Computer agents that power the Zouroboros memory and self-enhancement pipeline.
 
-These agents run on the Zo platform (`create_agent` / `edit_agent`). This directory is the **source of truth** for their configuration — `zouroboros doctor` verifies they are registered and active.
+These agents run on the Zo platform (`create_agent` / `edit_agent`). This directory is the **source of truth** for their configuration, but it is **not auto-deployed** — any live agent changes must be synced to the platform separately.
 
 ## Daily Pipeline (America/Phoenix)
 
@@ -41,12 +41,12 @@ vault-indexer (independent, hourly)
 zouroboros agents sync
 ```
 
-This writes the marker so `doctor` reports them as registered.
+This writes only the local marker so `doctor` reports them as registered. It does **not** create or update the live Zo agents.
 
 ## Updating an Agent
 
 1. Edit the spec in `manifest.json`
-2. Use `edit_agent` in Zo Chat to sync the change to the platform
+2. Use `edit_agent` in Zo Chat to sync the change to the live platform agent
 3. Commit the manifest update
 
 The manifest is not auto-deployed — it's a reference that keeps agent configs version-controlled.

--- a/packages/memory/docs/SKILL.md
+++ b/packages/memory/docs/SKILL.md
@@ -343,11 +343,14 @@ Extends memory capture beyond swarm tasks to **all conversations**. Scans worksp
 # List all capturable artifacts
 bun scripts/conversation-capture.ts --list
 
-# Process all new artifacts
+# Process last 24h (safe default)
 bun scripts/conversation-capture.ts
 
 # Only last 24 hours
 bun scripts/conversation-capture.ts --since 24h
+
+# Explicit full backlog sweep
+bun scripts/conversation-capture.ts --all
 
 # Preview without storing
 bun scripts/conversation-capture.ts --dry-run
@@ -360,7 +363,8 @@ bun scripts/conversation-capture.ts --stats
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--since <duration>` | Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m | all |
+| `--since <duration>` | Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m | 24h |
+| `--all` | Process all uncaptured artifacts across all conversations | false |
 | `--dry-run` | Show extraction without storing | false |
 | `--list` | List capturable files with status | — |
 | `--stats` | Show conversation capture statistics | — |
@@ -372,6 +376,7 @@ bun scripts/conversation-capture.ts --stats
 - Only processes `.md`, `.txt`, `.json` files
 - Hash-based dedup via `capture_log` table (never re-processes same content)
 - Creates episodes for each capture session
+- Bare invocation is intentionally bounded to the last 24 hours; use `--all` only for an explicit backlog sweep
 
 ### Scheduled Agent
 

--- a/packages/memory/src/standalone/conversation-capture.ts
+++ b/packages/memory/src/standalone/conversation-capture.ts
@@ -9,9 +9,10 @@
  * This extends memory capture beyond swarm tasks to ALL conversations.
  *
  * Usage:
- *   bun conversation-capture.ts                    # Process all new artifacts
+ *   bun conversation-capture.ts                    # Process last 24h (safe default)
  *   bun conversation-capture.ts --since 24h        # Only last 24 hours
  *   bun conversation-capture.ts --since 7d         # Only last 7 days
+ *   bun conversation-capture.ts --all              # Process all uncaptured artifacts
  *   bun conversation-capture.ts --dry-run           # Preview without storing
  *   bun conversation-capture.ts --stats             # Show capture statistics
  *   bun conversation-capture.ts --list              # List capturable files
@@ -584,15 +585,17 @@ async function main() {
 conversation-capture — Workspace Artifact Memory Capture
 
 Usage:
-  bun conversation-capture.ts                    # Process all new artifacts
+  bun conversation-capture.ts                    # Process last 24h (safe default)
   bun conversation-capture.ts --since 24h        # Only last 24 hours
   bun conversation-capture.ts --since 7d         # Only last 7 days
-  bun conversation-capture.ts --dry-run           # Preview without storing
-  bun conversation-capture.ts --stats             # Show capture statistics
-  bun conversation-capture.ts --list              # List capturable files
+  bun conversation-capture.ts --all              # Process all uncaptured artifacts
+  bun conversation-capture.ts --dry-run          # Preview without storing
+  bun conversation-capture.ts --stats            # Show capture statistics
+  bun conversation-capture.ts --list             # List capturable files
 
 Options:
   --since <duration>   Filter by recency: 1h, 24h, 7d, 30d, 1w, 1m
+  --all                Process all uncaptured artifacts across all conversations
   --dry-run            Show extracted facts without storing
   --stats              Show capture statistics
   --list               List capturable artifact files
@@ -606,9 +609,19 @@ Options:
   }
 
   const dryRun = args.includes("--dry-run");
+  const captureAll = args.includes("--all");
   let sinceDate: Date | undefined;
   const sinceIdx = args.indexOf("--since");
   if (sinceIdx >= 0 && args[sinceIdx + 1]) sinceDate = parseSince(args[sinceIdx + 1]);
+
+  if (captureAll && sinceDate) {
+    console.error("Use either --all or --since <duration>, not both.");
+    process.exit(1);
+  }
+
+  if (!captureAll && !sinceDate) {
+    sinceDate = parseSince("24h");
+  }
 
   if (args.includes("--list") || args[0] === "list") {
     listArtifacts(sinceDate);
@@ -634,7 +647,7 @@ Options:
     process.exit(0);
   }
 
-  console.log(`Found ${newArtifacts.length} new artifacts to capture${sinceDate ? ` (since ${sinceDate.toISOString().slice(0, 10)})` : ""}`);
+  console.log(`Found ${newArtifacts.length} new artifacts to capture${captureAll ? " (full backlog sweep)" : sinceDate ? ` (since ${sinceDate.toISOString().slice(0, 10)})` : ""}`);
   console.log(`Mode: ${dryRun ? "DRY RUN" : "LIVE"}\n`);
 
   await processArtifacts(newArtifacts, dryRun);

--- a/packages/swarm/src/rag/enrichment.ts
+++ b/packages/swarm/src/rag/enrichment.ts
@@ -9,6 +9,7 @@
  *
  * Ported from scripts/rag-enrichment.ts for package integration.
  */
+import { emitRAGTelemetry, matchedKeywords } from './telemetry.js';
 
 interface RAGResult {
   content: string;
@@ -150,28 +151,76 @@ export async function enrichTaskWithRAG(
   options: RAGEnrichmentOptions = {},
 ): Promise<{ context: string; latencyMs: number; patterns: number }> {
   const startTime = Date.now();
+  const triggered = shouldEnrichWithRAG(taskText);
+  const triggerKeywords = matchedKeywords(taskText, RAG_TRIGGER_KEYWORDS);
+  const taskTextHead = taskText.slice(0, 120);
 
-  if (!shouldEnrichWithRAG(taskText)) {
+  if (!triggered) {
+    void emitRAGTelemetry({
+      taskTextHead,
+      triggered: false,
+      triggerKeywords,
+      totalLatencyMs: 0,
+    });
     return { context: '', latencyMs: 0, patterns: 0 };
   }
 
+  let embedLatencyMs = 0;
+  let searchLatencyMs = 0;
   try {
+    const embedStart = Date.now();
     const embedding = await getOllamaEmbedding(taskText);
+    embedLatencyMs = Date.now() - embedStart;
+
+    const searchStart = Date.now();
     const results = await searchQdrant(embedding, {
       topK: options.topK || 3,
       minScore: options.minScore || 0.5,
       ...options,
     });
+    searchLatencyMs = Date.now() - searchStart;
 
-    if (results.length === 0) {
-      return { context: '', latencyMs: Date.now() - startTime, patterns: 0 };
+    const topScore = results[0]?.score ?? 0;
+    const hits = results.length;
+    const totalLatencyMs = Date.now() - startTime;
+
+    void emitRAGTelemetry({
+      taskTextHead,
+      triggered: true,
+      triggerKeywords,
+      collectionsQueried: ['code-docs'],
+      perCollectionTopScore: { 'code-docs': topScore },
+      perCollectionHits: { 'code-docs': hits },
+      mergedTopK: hits,
+      topScore,
+      patterns: hits,
+      embedLatencyMs,
+      searchLatencyMs,
+      totalLatencyMs,
+      errored: false,
+    });
+
+    if (hits === 0) {
+      return { context: '', latencyMs: totalLatencyMs, patterns: 0 };
     }
 
     const context = formatRAGContext(results);
-    return { context, latencyMs: Date.now() - startTime, patterns: results.length };
+    return { context, latencyMs: totalLatencyMs, patterns: hits };
   } catch (error) {
+    const totalLatencyMs = Date.now() - startTime;
+    void emitRAGTelemetry({
+      taskTextHead,
+      triggered: true,
+      triggerKeywords,
+      collectionsQueried: ['code-docs'],
+      embedLatencyMs,
+      searchLatencyMs,
+      totalLatencyMs,
+      errored: true,
+      errorMsg: String(error),
+    });
     console.log(`  [RAG] Enrichment failed (non-blocking): ${error}`);
-    return { context: '', latencyMs: Date.now() - startTime, patterns: 0 };
+    return { context: '', latencyMs: totalLatencyMs, patterns: 0 };
   }
 }
 

--- a/packages/swarm/src/rag/index.ts
+++ b/packages/swarm/src/rag/index.ts
@@ -10,3 +10,9 @@ export {
   fetchDomainContext,
   enrichTasksWithDomainContext,
 } from './domain-context.js';
+
+export {
+  emitRAGTelemetry,
+  matchedKeywords,
+  type RAGTelemetryRecord,
+} from './telemetry.js';

--- a/packages/swarm/src/rag/telemetry.ts
+++ b/packages/swarm/src/rag/telemetry.ts
@@ -1,0 +1,70 @@
+/**
+ * RAG Telemetry Sink
+ *
+ * Emits per-enrichment-call JSONL records to /dev/shm/rag-telemetry.jsonl.
+ * Non-blocking, fire-and-forget. Failures are swallowed.
+ *
+ * Each record captures: trigger match, collections queried, per-collection
+ * top score, merged topK, latency breakdown, pattern count.
+ *
+ * Consumed by the /api/rag-telemetry zo.space route and the
+ * /dashboard/rag-telemetry page.
+ */
+import { appendFile } from 'fs/promises';
+
+export interface RAGTelemetryRecord {
+  ts: string;
+  taskId?: string;
+  taskTextHead: string;
+  triggered: boolean;
+  triggerKeywords: string[];
+  collectionsQueried: string[];
+  perCollectionTopScore: Record<string, number>;
+  perCollectionHits: Record<string, number>;
+  mergedTopK: number;
+  topScore: number;
+  patterns: number;
+  embedLatencyMs: number;
+  searchLatencyMs: number;
+  totalLatencyMs: number;
+  errored: boolean;
+  errorMsg?: string;
+  runId?: string;
+  condition?: string;
+}
+
+const TELEMETRY_PATH = process.env.RAG_TELEMETRY_PATH || '/dev/shm/rag-telemetry.jsonl';
+const TELEMETRY_DISABLED = process.env.RAG_TELEMETRY_DISABLED === '1';
+
+export async function emitRAGTelemetry(record: Partial<RAGTelemetryRecord>): Promise<void> {
+  if (TELEMETRY_DISABLED) return;
+  const full: RAGTelemetryRecord = {
+    ts: new Date().toISOString(),
+    taskTextHead: '',
+    triggered: false,
+    triggerKeywords: [],
+    collectionsQueried: [],
+    perCollectionTopScore: {},
+    perCollectionHits: {},
+    mergedTopK: 0,
+    topScore: 0,
+    patterns: 0,
+    embedLatencyMs: 0,
+    searchLatencyMs: 0,
+    totalLatencyMs: 0,
+    errored: false,
+    runId: process.env.RAG_RUN_ID,
+    condition: process.env.RAG_CONDITION,
+    ...record,
+  };
+  try {
+    await appendFile(TELEMETRY_PATH, JSON.stringify(full) + '\n', 'utf8');
+  } catch {
+    // swallow — telemetry must never break the enrichment path
+  }
+}
+
+export function matchedKeywords(taskText: string, keywords: string[]): string[] {
+  const lower = taskText.toLowerCase();
+  return keywords.filter(kw => lower.includes(kw));
+}


### PR DESCRIPTION
## Summary
- make `conversation-capture` safe by default by bounding bare invocation to the last 24 hours
- require explicit `--all` for intentional backlog sweeps
- clarify in agent docs that `zouroboros agents sync` only writes a local marker and does not update live Zo agents
- add RAG telemetry hooks around swarm enrichment so Mimir-related insertion points are observable

## Problem
A recent fact-volume spike showed that at least one invocation path behaved like an unbounded `conversation-capture.ts` run rather than the intended `--since 24h` path. That created two issues:
- capture safety depended too much on callers remembering the correct flag
- the live/deployed agent state could drift from the repo manifest without the docs making that risk explicit

At the same time, the newer Mimir/RAG insertion points lacked telemetry, which made it harder to observe when enrichment triggered and how it behaved.

## Root Cause
- the repo manifest specifies `conversation-capture.ts --since 24h`, but at least one live invocation surface behaved like a bare `conversation-capture.ts` run
- bare invocation previously allowed an unbounded scan of uncaptured conversation artifacts
- repo guidance around agent sync could be misread as deployment rather than local registration tracking

## Changes
### Capture guardrails
- changed bare `conversation-capture.ts` invocation to default to a 24-hour bounded window
- added `--all` for explicit full backlog sweeps
- added validation to reject `--all` together with `--since`
- updated help text to make the safety model obvious

### Docs and operator guidance
- updated memory skill docs to reflect the new safe default
- clarified operator guidance for Memory Manager usage
- clarified in `agents/README.md` that `zouroboros agents sync` is marker-only and that live agent changes still require Zo-side sync

### RAG telemetry
- added a telemetry sink for RAG enrichment
- emit trigger, keyword, score, hit-count, latency, and error data from swarm enrichment
- export telemetry helpers from the RAG index

## Impact
- accidental backlog sweeps now require an explicit operator choice
- local CLI behavior is safer even when callers omit `--since`
- reviewers/operators get clearer deployment semantics for scheduled agents
- Mimir-related enrichment behavior is now observable for future debugging and tuning

## Validation
- `bun /home/workspace/Skills/zo-memory-system/scripts/conversation-capture.ts --help`
- `bun /home/workspace/Skills/zo-memory-system/scripts/conversation-capture.ts --all --since 24h`
- `timeout 20 bun /home/workspace/Skills/zo-memory-system/scripts/conversation-capture.ts --dry-run`
- `cd /home/workspace/zouroboros && bunx tsc --noEmit -p packages/memory/tsconfig.json`
- `cd /home/workspace/zouroboros && bunx tsc --noEmit -p packages/swarm/tsconfig.json`

## Notes
This PR does not itself edit the live Zo scheduled agent. It makes the local/runtime path safer and documents the remaining Zo-side sync requirement explicitly.